### PR TITLE
Performance Review - CLI Optimization Recommendations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "afk"
-version = "0.4.21"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,15 +22,17 @@ dependencies = [
  "crossterm",
  "ctrlc",
  "notify",
+ "portable-pty",
  "predicates",
  "ratatui",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
+ "strip-ansi-escapes",
  "tempfile",
  "tera",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "toml",
 ]
@@ -575,15 +577,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
 dependencies = [
  "dispatch2",
- "nix",
+ "nix 0.30.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -591,10 +593,11 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
+ "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -604,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -657,6 +660,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -728,6 +737,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -819,7 +839,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -827,12 +846,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
@@ -853,13 +866,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-io",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -1319,15 +1328,24 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
 dependencies = [
  "darling",
  "indoc",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1495,6 +1513,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1586,20 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -1927,6 +1968,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.25.1",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,9 +2202,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2370,6 +2430,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,6 +2481,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -2472,6 +2590,15 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
 
 [[package]]
 name = "strsim"
@@ -2595,6 +2722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,11 +2738,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.17",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2663,23 +2819,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio 1.1.1",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
- "tokio-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2912,6 +3054,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -3367,6 +3518,15 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,12 +29,12 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "strip-ansi-escapes",
  "tempfile",
  "tera",
  "thiserror 2.0.17",
  "tokio",
  "toml",
+ "vte",
 ]
 
 [[package]]
@@ -142,6 +142,12 @@ dependencies = [
  "windows-sys 0.60.2",
  "x11rb",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_cmd"
@@ -2592,15 +2598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "strip-ansi-escapes"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
-dependencies = [
- "vte",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3061,6 +3058,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
+ "arrayvec",
  "memchr",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ serde_json = "1.0"
 # Date/time handling
 chrono = { version = "0.4", features = ["serde"] }
 
-# Async runtime
-tokio = { version = "1.43", features = ["full"] }
+# Async runtime (used by reqwest for HTTP in update command)
+tokio = { version = "1.43", features = ["rt"] }
 
 # Error handling
 anyhow = "1.0"
@@ -51,7 +51,15 @@ ratatui = "0.29"
 crossterm = "0.28"
 
 # HTTP client for self-update
-reqwest = { version = "0.12", features = ["blocking", "json"] }
+reqwest = { version = "0.12", features = ["json"] }
+
+# PTY support (opt-in)
+portable-pty = { version = "0.8", optional = true }
+strip-ansi-escapes = { version = "0.2", optional = true }
+
+[features]
+default = []
+pty = ["portable-pty", "strip-ansi-escapes"]
 
 [dev-dependencies]
 tempfile = "3.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,11 @@ reqwest = { version = "0.12", features = ["json"] }
 
 # PTY support (opt-in)
 portable-pty = { version = "0.8", optional = true }
-strip-ansi-escapes = { version = "0.2", optional = true }
+vte = { version = "0.14", optional = true }
 
 [features]
 default = []
-pty = ["portable-pty", "strip-ansi-escapes"]
+pty = ["portable-pty", "vte"]
 
 [dev-dependencies]
 tempfile = "3.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "afk"
-version = "0.4.21"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Autonomous AI coding loops - Ralph Wiggum style"

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Installs a standalone binary - no dependencies required. Updates with `afk updat
 git clone https://github.com/m0nkmaster/afk.git && cd afk
 cargo build --release
 # Binary at target/release/afk
+
+# Optional: enable PTY-based AI CLI spawning (experimental)
+cargo build --release --features pty
 ```
 
 ### Cargo
@@ -228,7 +231,7 @@ Each task **must complete in a single AI context window**. Tasks that are too la
 4. **Spawn fresh AI** — a brand new CLI instance with clean context
 5. **AI works autonomously:**
    - Implements the task
-   - Runs `afk verify` (quality gates: lint, test, typecheck)
+   - Runs `afk verify` (quality gates run in parallel when configured)
    - Fixes issues until verify passes
    - Commits changes
    - Marks task complete in `.afk/tasks.json`
@@ -241,6 +244,7 @@ The key point: **afk is an orchestrator, not an AI itself**. It spawns your chos
 
 - **[docs/user-guide.md](docs/user-guide.md)** - Complete command reference and workflow examples
 - **[docs/architecture.md](docs/architecture.md)** - Technical overview for contributors
+- **[docs/performance-review.md](docs/performance-review.md)** - Bottlenecks, fixes, and implementation status
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** - How to contribute
 
 ## 🙏 Inspired By

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,8 @@ src/
 │   ├── controller.rs # Loop lifecycle management
 │   ├── iteration.rs  # Single iteration execution
 │   ├── output_handler.rs # Console output
+│   ├── output_sink.rs # Shared console/TUI streaming sink
+│   ├── pty_spawn.rs   # PTY subprocess adapter (feature-gated)
 │   ├── quality_gates.rs  # Lint, test, type checks
 │   └── sleep_guard.rs    # System sleep prevention
 ├── git/             # Git integration
@@ -81,7 +83,8 @@ src/
     ├── json.rs      # JSON PRD files
     ├── markdown.rs  # Markdown checklists
     ├── github.rs    # GitHub issues via gh CLI
-    └── openspec.rs  # OpenSpec change proposals
+    ├── openspec.rs  # OpenSpec change proposals
+    └── gherkin.rs   # Gherkin/BDD .feature files
 ```
 
 ## Key Dependencies
@@ -97,8 +100,9 @@ src/
 | `arboard` | Cross-platform clipboard access |
 | `ctrlc` | Signal handling for graceful shutdown |
 | `ratatui` / `crossterm` | Terminal UI framework for TUI mode |
-| `tokio` | Async runtime |
+| `tokio` | Lightweight runtime for async update checks |
 | `reqwest` | HTTP client for self-update |
+| `portable-pty` / `strip-ansi-escapes` | Optional PTY output path (`pty` feature) |
 | `anyhow` / `thiserror` | Error handling |
 
 ## Data Flow
@@ -143,16 +147,24 @@ pub struct AfkConfig {
 
 ### Task Aggregation
 
-Sources implement a common pattern returning `Vec<UserStory>`:
+Sources are loaded with a single-source fast path and parallel fan-out for multi-source configs:
 
 ```rust
 pub fn aggregate_tasks(sources: &[SourceConfig]) -> Vec<UserStory> {
-    let mut all_tasks = Vec::new();
-    for source in sources {
-        let tasks = load_from_source(source);
-        all_tasks.extend(tasks);
+    if sources.len() <= 1 {
+        return sources.iter().flat_map(load_from_source).collect();
     }
-    all_tasks
+
+    let handles: Vec<_> = sources
+        .iter()
+        .cloned()
+        .map(|source| thread::spawn(move || load_from_source(&source)))
+        .collect();
+
+    handles
+        .into_iter()
+        .flat_map(|h| h.join().unwrap_or_default())
+        .collect()
 }
 ```
 
@@ -180,9 +192,11 @@ The runner implements the core pattern:
 
 ```rust
 pub fn run_loop(config: &AfkConfig, iterations: Option<u32>, ...) -> LoopResult {
+    let mut prd_cache = PrdCache::new(&initial_prd);
+
     loop {
-        // 1. Load current state
-        let prd = PrdDocument::load(None)?;
+        // 1. Refresh current state (mtime-aware cache)
+        let prd = prd_cache.get(&initial_prd).clone();
         let mut progress = SessionProgress::load(None)?;
         
         // 2. Check stop conditions
@@ -198,7 +212,7 @@ pub fn run_loop(config: &AfkConfig, iterations: Option<u32>, ...) -> LoopResult 
         // 5. Spawn fresh AI CLI with selected model
         let output = spawn_ai_cli(&config.ai_cli, &prompt, model)?;
         
-        // 6. Run quality gates
+        // 6. Run quality gates (executed in parallel)
         let gates = run_quality_gates(&config.feedback_loops)?;
         
         // 7. Auto-commit if gates pass
@@ -236,24 +250,16 @@ The selected model is passed via `--model <name>` to the AI CLI. This brings dif
 
 ### Quality Gates
 
-Gates run sequentially and report results:
+Gates run concurrently and report a combined result:
 
 ```rust
 pub fn run_quality_gates(config: &FeedbackLoopsConfig, verbose: bool) -> GatesResult {
-    let mut results = Vec::new();
-    
-    if let Some(ref cmd) = config.types {
-        results.push(run_gate("types", cmd, verbose));
-    }
-    if let Some(ref cmd) = config.lint {
-        results.push(run_gate("lint", cmd, verbose));
-    }
+    let handles = collect_gates(config)
+        .into_iter()
+        .map(|(name, cmd)| thread::spawn(move || run_single_gate(&name, &cmd)))
+        .collect::<Vec<_>>();
+    // join handles and accumulate status
     // ...
-    
-    GatesResult {
-        all_passed: results.iter().all(|r| r.passed),
-        results,
-    }
 }
 ```
 
@@ -322,7 +328,9 @@ pub enum SourceError {
 
 - **Startup time**: Rust provides fast cold start (~10ms)
 - **Memory**: Single-pass processing, no persistent runtime
-- **I/O**: Async file operations via tokio where beneficial
+- **I/O**: PRD mtime cache avoids redundant hot-loop reloads
+- **Streaming**: shared output sink removes duplicate console/TUI parsing logic
+- **Parallelism**: task source loading and quality gates run concurrently
 - **Binary size**: ~5-10MB depending on platform and optimisation
 
 ## Cross-Platform Support

--- a/docs/performance-review.md
+++ b/docs/performance-review.md
@@ -6,7 +6,23 @@
 
 ## Executive Summary
 
-`afk` is a well-structured Rust CLI tool, but its current architecture leaves meaningful performance on the table in three areas: **startup overhead from sequential I/O**, **inefficient process I/O streaming**, and **untapped parallelism** during multi-task runs. The recommendations below are prioritised by impact-to-effort ratio.
+`afk` is a well-structured Rust CLI tool, but its current architecture leaves meaningful performance on the table in three areas: **startup overhead from sequential I/O**, **inefficient process I/O streaming**, and **untapped parallelism** during multi-task runs. There are also **correctness issues** that interact with performance: a pipe-buffer deadlock in quality gates, divergent behaviour between TUI and non-TUI streaming paths, and phantom iteration counting. The recommendations below are prioritised by impact-to-effort ratio, with correctness fixes elevated accordingly.
+
+---
+
+## Implementation Status (Performance Branch)
+
+As of 2026-03-24, the branch has implemented phases 1-7 from the follow-up plan:
+
+- **Phase 1 (quick wins):** done - single-string output accumulation, prompt `HashMap` pre-sizing, phantom-iteration fix, and template cache
+- **Phase 2 (quality gates):** done - concurrent stdout/stderr draining plus parallel gate execution
+- **Phase 3 (hot-loop I/O):** done - PRD mtime cache in the loop controller
+- **Phase 4 (sources):** done - multi-source aggregation now loads sources in parallel with a single-source fast path
+- **Phase 5 (streaming dedup):** done - shared `OutputSink` flow in `src/runner/output_sink.rs`, fixing TUI NDJSON leakage
+- **Phase 6 (PTY spike):** done - optional PTY path (`pty` feature), PTY spawn adapter, and validation example in `examples/pty_spike.rs`
+- **Phase 7 (reqwest):** done - moved update path from `reqwest::blocking` to async `reqwest::Client`
+
+The remaining item from the original review is the future worktree-based parallel runner (section 2.7), which is intentionally deferred.
 
 ---
 
@@ -24,26 +40,26 @@ let prd = PrdDocument::load(tasks_path.as_deref())?;                  // disk re
 progress.save(progress_save_path.as_deref())?;                        // disk write
 ```
 
-And in the main loop (`controller.rs`), `PrdDocument::load` is called **again** every iteration to detect task completion:
+And in the main loop (`controller.rs`), `PrdDocument::load` is called **again** every iteration to detect task completion. Both the non-TUI path (`run_main_loop`, lines 220 and 295) and the TUI path (`run_loop_with_tui_sender`, lines 629 and 723) contain the same pair of redundant loads:
 
 ```rust
-// src/runner/controller.rs – inside the hot loop
+// src/runner/controller.rs – inside both hot loop variants (lines 220/629 and 295/723)
 let mut current_prd = match PrdDocument::load(None) {
     Ok(p) => p,
     Err(_) => prd.clone(),
 };
-// ...
+// ... ~75 lines later in the same loop iteration ...
 let updated_prd = PrdDocument::load(None).unwrap_or(current_prd.clone());
 ```
 
-This means **3–4 JSON file reads per iteration** even for a simple one-task session.
+This means **3 file I/O operations per iteration** (2 PRD reads + 1 progress write) even for a simple one-task session.
 
 ### 1.2 No PTY — AI CLIs Lose Interactivity
 
-The subprocess is spawned with `Stdio::piped()` on all three handles:
+The subprocess is spawned with `Stdio::piped()` in both code paths — `iteration.rs` (line 245) and `controller.rs` `build_ai_command` (lines 820–821):
 
 ```rust
-// src/runner/iteration.rs
+// src/runner/iteration.rs (line 245) and controller.rs build_ai_command (line 820)
 cmd.args(&args)
     .arg(prompt)
     .stdin(Stdio::null())
@@ -60,7 +76,9 @@ The result is that the current pipeline adds **artificial latency** between the 
 
 ### 1.3 Duplicate Output Streaming Logic
 
-`controller.rs` contains a complete copy of the iteration streaming loop (`run_iteration_with_tui`) that is largely a reimplementation of what `IterationRunner::execute_command` in `iteration.rs` already does. This means bug fixes and performance improvements must be applied in two places, and the code paths diverge in subtle ways. Neither path currently uses async I/O.
+`controller.rs` contains a complete copy of the iteration streaming loop (`run_iteration_with_tui`) that is largely a reimplementation of what `IterationRunner::execute_command` in `iteration.rs` already does. This means bug fixes and performance improvements must be applied in two places, and the code paths have **already diverged with a user-visible bug**: the TUI path (line 1083) sends raw unparsed NDJSON lines directly to the display when the `StreamJsonParser` returns `None`, while the non-TUI path in `iteration.rs` correctly suppresses them. Users of the TUI see raw JSON noise that the non-TUI path filters out.
+
+The duplication goes deeper than just streaming — `run_main_loop` and `run_loop_with_tui_sender` duplicate ~100 lines of loop-control logic (interrupt check, timeout check, iteration limit, PRD load, completion check, source sync, pending tasks, run iteration, task completion sync). Neither path currently uses async I/O.
 
 ### 1.4 Quality Gates Run Sequentially
 
@@ -111,13 +129,36 @@ This allocates one `String` per line of AI output, then concatenates them all in
 
 ### 1.8 reqwest Blocking Client in Binary
 
-`Cargo.toml` pulls in `reqwest` with the `blocking` feature for the self-update path. The blocking client starts its own Tokio runtime internally. Since the binary already has a Tokio runtime (`tokio = { features = ["full"] }`), this creates two runtimes — one of which sits idle for the entire session.
+`Cargo.toml` pulls in `reqwest` with the `blocking` feature for the self-update path. The blocking client starts its own Tokio runtime internally. Since the binary already has a Tokio runtime (`tokio = { features = ["full"] }`), this creates two runtimes. Note: the blocking runtime is only created when the update-check code path is actually invoked, not at process startup, so the overhead is limited to runs that trigger an update check.
+
+### 1.9 Quality Gate Pipe Deadlock
+
+In `run_single_gate` (`quality_gates.rs`, lines 170–183), stdout is read to completion before stderr is read:
+
+```rust
+if let Some(stdout) = process.stdout.take() {
+    let reader = BufReader::new(stdout);
+    for line in reader.lines().map_while(Result::ok) { ... }
+}
+if let Some(stderr) = process.stderr.take() {
+    let reader = BufReader::new(stderr);
+    for line in reader.lines().map_while(Result::ok) { ... }
+}
+```
+
+If a gate command writes more data to stderr than fits in the OS pipe buffer (~64 KB on Linux, ~512 KB on macOS) while stdout is being drained, the subprocess blocks writing to stderr while the parent blocks reading stdout. This is a textbook pipe-buffer deadlock. The fix is to read both streams concurrently (two threads or non-blocking reads).
+
+Additionally, the `verbose` parameter is accepted as `_verbose` (line 142) and never used — verbose output is collected but never conditionally printed.
+
+### 1.10 Progress File Written on No-Op Iterations
+
+`generate_prompt_with_root` increments and saves the iteration counter to disk (line 123 in `prompt/mod.rs`) before returning the prompt. If the caller detects `AFK_COMPLETE` in the prompt and returns early (controller.rs line 1025), the progress file has already been written with an incremented count — recording a phantom iteration that never actually ran.
 
 ---
 
 ## 2. Recommended Optimisations
 
-### 2.1 (HIGH IMPACT) Use a PTY for AI CLI Subprocess
+### 2.1 (HIGH IMPACT — requires validation spike) Use a PTY for AI CLI Subprocess
 
 Replace `Stdio::piped()` with a PTY so AI CLIs see a real terminal. The `portable-pty` crate provides cross-platform PTY support.
 
@@ -152,7 +193,7 @@ fn spawn_with_pty(cmd_parts: &[String], prompt: &str) -> Result<Box<dyn std::io:
 
 The `slave` end acts as the AI CLI's stdin/stdout/stderr. Because the PTY presents as a TTY, the AI CLI enables interactive output. Read from `master` as normal.
 
-**Caveat:** PTY output includes ANSI escape sequences. Strip them before passing to your NDJSON parser with a small state machine or the `strip-ansi-escapes` crate.
+**Caveat — NDJSON correctness risk:** PTY output includes ANSI escape sequences (colours, cursor movement, etc.). These sequences can appear mid-line and even span line boundaries during cursor repositioning. The `StreamJsonParser` expects clean JSON lines — ANSI sequences injected into the stream will corrupt JSON parsing and cause silent fallback to raw line display. A simple per-line `strip-ansi-escapes` pass is insufficient for cursor-movement sequences that span lines. **A validation spike is recommended before committing to this approach**: spawn a real AI CLI under a PTY, capture the raw byte stream, and verify that stripping produces parseable NDJSON before investing in the full integration. Both spawn sites (`iteration.rs` line 245 and `controller.rs` line 820) must be updated.
 
 ### 2.2 (HIGH IMPACT) Parallelise Quality Gates with Rayon or Threads
 
@@ -194,27 +235,32 @@ For three typical gates (clippy ~2 s, tests ~5 s, format ~0.5 s), this reduces w
 
 ### 2.3 (HIGH IMPACT) Cache the Tera Template Across Iterations
 
-Move template compilation out of `generate_prompt_with_root` into a `OnceLock` or pass a compiled `Tera` instance through `AfkConfig`:
+Move template compilation out of `generate_prompt_with_root` into a cache keyed on the template content. A `Mutex`-guarded cache with key comparison handles the case where the template changes mid-session (e.g., user edits a custom template):
 
 ```rust
 // src/prompt/mod.rs
-use std::sync::OnceLock;
+use std::sync::Mutex;
 
-static COMPILED_TEMPLATE: OnceLock<(String, Tera)> = OnceLock::new();
+static TEMPLATE_CACHE: Mutex<Option<(String, Tera)>> = Mutex::new(None);
 
-fn get_compiled_tera(template_str: &str) -> Result<&'static Tera, tera::Error> {
-    // Recompile only if template string changed (e.g., user edited custom template)
-    // For simplicity, compile once per process lifetime
-    let (_, tera) = COMPILED_TEMPLATE.get_or_try_init(|| {
-        let mut tera = Tera::default();
-        tera.add_raw_template("prompt", template_str)?;
-        Ok::<_, tera::Error>((template_str.to_string(), tera))
-    })?;
+fn get_compiled_tera(template_str: &str) -> Result<Tera, tera::Error> {
+    let mut cache = TEMPLATE_CACHE.lock().unwrap();
+
+    if let Some((cached_key, cached_tera)) = cache.as_ref() {
+        if cached_key == template_str {
+            return Ok(cached_tera.clone());
+        }
+    }
+
+    // Template changed or first call — recompile
+    let mut tera = Tera::default();
+    tera.add_raw_template("prompt", template_str)?;
+    *cache = Some((template_str.to_string(), tera.clone()));
     Ok(tera)
 }
 ```
 
-For a 20-iteration session, this eliminates 19 template compilations.
+For a 20-iteration session with a stable template, this eliminates 19 template compilations. Unlike a bare `OnceLock`, this correctly handles custom templates that differ from the default — the cache invalidates when the template string changes.
 
 ### 2.4 (MEDIUM IMPACT) Parallelise Source Loading
 
@@ -235,12 +281,18 @@ pub fn aggregate_tasks(sources: &[SourceConfig]) -> Vec<UserStory> {
 
     handles
         .into_iter()
-        .flat_map(|h| h.join().unwrap_or_default())
+        .flat_map(|h| match h.join() {
+            Ok(tasks) => tasks,
+            Err(e) => {
+                eprintln!("Warning: source loader thread panicked: {:?}", e);
+                vec![]
+            }
+        })
         .collect()
 }
 ```
 
-When using beads + GitHub + JSON simultaneously, this turns three sequential process/network calls into one parallel batch.
+When using beads + GitHub + JSON simultaneously, this turns three sequential process/network calls into one parallel batch. Note: handles are joined in spawn order, preserving source-declaration ordering.
 
 ### 2.5 (MEDIUM IMPACT) Reduce Disk I/O in the Hot Loop
 
@@ -273,7 +325,9 @@ impl PrdCache {
 }
 ```
 
-This replaces `PrdDocument::load(None)` in the loop with a stat + conditional read, reducing the common case from a full JSON parse to a single `stat()` syscall.
+This replaces `PrdDocument::load(None)` in both loop variants (non-TUI and TUI paths) with a stat + conditional read, reducing the common case from a full JSON parse to a single `stat()` syscall.
+
+**Note:** mtime resolution on some filesystems (FAT32, older HFS+) can be 1–2 seconds, so a change written and re-read within a second could be missed. On modern APFS/ext4 this is not a practical concern.
 
 ### 2.6 (MEDIUM IMPACT) Switch Output Buffer to a Single Growing String
 
@@ -382,7 +436,7 @@ reqwest = { version = "0.12", features = ["json"] }
 // or run the check lazily after the main loop completes
 ```
 
-This reduces startup overhead by avoiding the creation of a second hidden thread pool.
+This avoids the creation of a second hidden Tokio runtime when the update-check path is invoked. The overhead is limited to runs that trigger an update check, so this is a cleanliness improvement rather than a startup-time fix.
 
 ### 2.9 (LOW IMPACT) Pre-size HashMaps with Known Capacity
 
@@ -398,13 +452,16 @@ let gate_count = [
 let mut feedback_loops: HashMap<String, String> = HashMap::with_capacity(gate_count);
 ```
 
-### 2.10 (LOW IMPACT) Deduplicate Streaming Logic
+### 2.10 (HIGH IMPACT) Deduplicate Streaming and Loop-Control Logic
 
-`controller.rs` (`run_iteration_with_tui`) and `iteration.rs` (`execute_command`) contain near-identical output streaming loops. Merging them into a single `stream_output` function with a trait-based sink reduces binary size, compile time, and maintenance burden:
+This is higher-impact than it appears. The duplication between `controller.rs` and `iteration.rs` has **already caused a bug**: the TUI path sends raw unparsed NDJSON to the display (line 1083) while the non-TUI path correctly suppresses it. Beyond streaming, `run_main_loop` and `run_loop_with_tui_sender` duplicate ~100 lines of loop-control logic that will continue to diverge.
+
+Merge the streaming into a single `stream_output` function with a trait-based sink. Use separate trait methods for display vs events rather than combining them:
 
 ```rust
 trait OutputSink: Send {
-    fn on_line(&mut self, display: Option<String>, tui: Option<TuiEvent>);
+    fn on_display_line(&mut self, line: &str);
+    fn on_stream_event(&mut self, event: &StreamEvent);
 }
 
 struct ConsoleSink<'a>(&'a mut OutputHandler);
@@ -417,21 +474,25 @@ fn stream_output(
 ) -> (bool, String) { /* unified streaming logic */ }
 ```
 
+For the loop-control duplication, extract the shared iteration loop into a single function parameterised by the output sink, eliminating the second copy entirely.
+
 ---
 
 ## 3. Prioritised Next Steps
 
 | Priority | Change | Estimated Speedup | Effort |
 |----------|--------|-------------------|--------|
-| **P0** | PTY-based subprocess spawning (2.1) | Eliminates buffering latency; unlocks AI CLI streaming features | Medium (2–3 days) |
 | **P0** | Parallel quality gates (2.2) | Saves `(N-1)` × avg gate time per iteration | Low (1 day) |
+| **P0** | Fix quality gate pipe deadlock (1.9) | Prevents hangs on verbose gate output | Low (1 day) |
+| **P1** | Deduplicate streaming + loop-control logic (2.10) | Correctness fix (TUI NDJSON bug); maintenance win | Medium (2–3 days) |
+| **P1** | PTY-based subprocess spawning (2.1) | Eliminates buffering latency; unlocks AI CLI streaming — requires validation spike first | Medium (2–3 days) |
 | **P1** | Cache compiled Tera template (2.3) | Removes template re-parse overhead on every iteration | Low (half day) |
 | **P1** | Reduce hot-loop disk I/O via mtime cache (2.5) | Replaces 2 JSON parses per iteration with `stat()` | Low (1 day) |
 | **P1** | Single-string output buffer (2.6) | Reduces allocator pressure for large AI responses | Low (hours) |
 | **P2** | Parallel source loading (2.4) | Cuts source sync time when using multiple adapters | Low (1 day) |
 | **P2** | Git worktrees for parallel task execution (2.7) | Can achieve N× throughput for independent tasks | High (1–2 weeks) |
-| **P3** | Deduplicate streaming logic (2.10) | Compile-time improvement; correctness benefit | Medium (2–3 days) |
-| **P3** | Async reqwest (2.8) | Removes hidden runtime overhead | Low (hours) |
+| **P2** | Fix progress write on no-op iterations (1.10) | Avoids phantom iteration counts | Low (hours) |
+| **P3** | Async reqwest (2.8) | Removes hidden runtime overhead on update-check path | Low (hours) |
 | **P3** | Pre-size HashMaps (2.9) | Micro-optimisation | Low (minutes) |
 
 ---
@@ -440,10 +501,12 @@ fn stream_output(
 
 These changes require < 30 minutes each and have no risk:
 
-- [ ] Replace `Vec<String>` output buffer with `String::with_capacity(64 * 1024)`
-- [ ] Add `HashMap::with_capacity` to feedback loops builder
-- [ ] Extract `run_single_gate` calls into `thread::spawn` joinset
-- [ ] Wrap `Tera` in `OnceLock` to avoid re-compilation
+- [x] Replace `Vec<String>` output buffer with `String::with_capacity(64 * 1024)` (handled via shared streaming output buffer)
+- [x] Add `HashMap::with_capacity` to feedback loops builder
+- [x] Extract `run_single_gate` calls into `thread::spawn` joinset
+- [x] Cache `Tera` in a `Mutex`-guarded cache keyed on template content (not a bare `OnceLock` — see 2.3)
+- [x] Read stdout and stderr concurrently in `run_single_gate` to prevent pipe deadlock (see 1.9)
+- [x] Remove dead `_verbose` parameter in `run_single_gate` or implement verbose output (implemented by removing dead parameter and printing output when `verbose`)
 
 ---
 

--- a/docs/performance-review.md
+++ b/docs/performance-review.md
@@ -1,0 +1,475 @@
+# afk Performance Review
+
+> Rust CLI expert review focused on startup latency, I/O throughput, and parallelism opportunities.
+
+---
+
+## Executive Summary
+
+`afk` is a well-structured Rust CLI tool, but its current architecture leaves meaningful performance on the table in three areas: **startup overhead from sequential I/O**, **inefficient process I/O streaming**, and **untapped parallelism** during multi-task runs. The recommendations below are prioritised by impact-to-effort ratio.
+
+---
+
+## 1. Current Performance Bottlenecks
+
+### 1.1 Sequential Blocking I/O at Startup
+
+Every `afk go` iteration calls `generate_prompt_with_root`, which performs three synchronous, sequential operations before any AI work begins:
+
+```rust
+// src/prompt/mod.rs – these run one after the other, blocking the thread
+let mut progress = SessionProgress::load(progress_path.as_deref())?;  // disk read
+let prd = PrdDocument::load(tasks_path.as_deref())?;                  // disk read
+// ...
+progress.save(progress_save_path.as_deref())?;                        // disk write
+```
+
+And in the main loop (`controller.rs`), `PrdDocument::load` is called **again** every iteration to detect task completion:
+
+```rust
+// src/runner/controller.rs – inside the hot loop
+let mut current_prd = match PrdDocument::load(None) {
+    Ok(p) => p,
+    Err(_) => prd.clone(),
+};
+// ...
+let updated_prd = PrdDocument::load(None).unwrap_or(current_prd.clone());
+```
+
+This means **3–4 JSON file reads per iteration** even for a simple one-task session.
+
+### 1.2 No PTY — AI CLIs Lose Interactivity
+
+The subprocess is spawned with `Stdio::piped()` on all three handles:
+
+```rust
+// src/runner/iteration.rs
+cmd.args(&args)
+    .arg(prompt)
+    .stdin(Stdio::null())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped());
+```
+
+Many AI CLIs (Claude, Cursor) detect whether stdout is a terminal. When they detect a plain pipe, they:
+- Disable colour output, progress bars, and streaming indicators
+- Sometimes buffer their output more aggressively (full buffering vs line buffering)
+- May switch to a lower-bandwidth output format
+
+The result is that the current pipeline adds **artificial latency** between the AI producing output and `afk` processing it, and may disable AI CLI streaming features that would otherwise give faster perceived response.
+
+### 1.3 Duplicate Output Streaming Logic
+
+`controller.rs` contains a complete copy of the iteration streaming loop (`run_iteration_with_tui`) that is largely a reimplementation of what `IterationRunner::execute_command` in `iteration.rs` already does. This means bug fixes and performance improvements must be applied in two places, and the code paths diverge in subtle ways. Neither path currently uses async I/O.
+
+### 1.4 Quality Gates Run Sequentially
+
+```rust
+// src/runner/quality_gates.rs
+for (name, cmd) in gates {
+    let gate_result = run_single_gate(&name, &cmd, verbose);
+    result.add_gate(gate_result);
+}
+```
+
+Lint, type-check, and test gates are completely independent — they can all run at the same time. On a project with `cargo clippy`, `cargo test`, and a custom `prettier --check`, sequential execution wastes wall-clock time equal to `(N-1)` gate durations.
+
+### 1.5 Source Aggregation Is Sequential
+
+```rust
+// src/sources/mod.rs
+pub fn aggregate_tasks(sources: &[SourceConfig]) -> Vec<UserStory> {
+    sources.iter().flat_map(load_from_source).collect()
+}
+```
+
+Each source (beads, GitHub, JSON) can involve subprocess calls (`bd`, `gh`) or network requests. These are fully independent and could run in parallel.
+
+### 1.6 Tera Template Re-initialised Every Iteration
+
+```rust
+// src/prompt/mod.rs – called every iteration
+let mut tera = Tera::default();
+tera.add_raw_template("prompt", &template_str)?;
+let prompt = tera.render("prompt", &context)?;
+```
+
+`Tera::default()` allocates and compiles the template every single iteration. Template compilation is not free — it involves parsing, AST construction, and bytecode generation.
+
+### 1.7 Output Buffer: `Vec<String>` + `concat()` Anti-pattern
+
+```rust
+// src/runner/iteration.rs and controller.rs
+let mut output_buffer = Vec::new();
+// ...
+output_buffer.push(format!("{line}\n"));
+// ...
+let output = output_buffer.concat();
+```
+
+This allocates one `String` per line of AI output, then concatenates them all into a second large `String`. For a 10,000-line response, this is ~10,000 small allocations. Prefer a single `String` grown with `push_str`.
+
+### 1.8 reqwest Blocking Client in Binary
+
+`Cargo.toml` pulls in `reqwest` with the `blocking` feature for the self-update path. The blocking client starts its own Tokio runtime internally. Since the binary already has a Tokio runtime (`tokio = { features = ["full"] }`), this creates two runtimes — one of which sits idle for the entire session.
+
+---
+
+## 2. Recommended Optimisations
+
+### 2.1 (HIGH IMPACT) Use a PTY for AI CLI Subprocess
+
+Replace `Stdio::piped()` with a PTY so AI CLIs see a real terminal. The `portable-pty` crate provides cross-platform PTY support.
+
+**Why this matters:** Claude and Cursor CLIs stream output differently when attached to a TTY. Line buffering on the AI CLI side means lower latency between tokens being produced and `afk` reading them. Some CLIs also enable richer structured output only when a TTY is present.
+
+```toml
+# Cargo.toml
+portable-pty = "0.8"
+```
+
+```rust
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+
+fn spawn_with_pty(cmd_parts: &[String], prompt: &str) -> Result<Box<dyn std::io::Read + Send>> {
+    let pty_system = native_pty_system();
+    let pair = pty_system.openpty(PtySize {
+        rows: 50,
+        cols: 220,
+        pixel_width: 0,
+        pixel_height: 0,
+    })?;
+
+    let mut cmd = CommandBuilder::new(&cmd_parts[0]);
+    cmd.args(&cmd_parts[1..]);
+    cmd.arg(prompt);
+
+    let _child = pair.slave.spawn_command(cmd)?;
+    // pair.master implements Read — stream it exactly like Stdio::piped()
+    Ok(pair.master.try_clone_reader()?)
+}
+```
+
+The `slave` end acts as the AI CLI's stdin/stdout/stderr. Because the PTY presents as a TTY, the AI CLI enables interactive output. Read from `master` as normal.
+
+**Caveat:** PTY output includes ANSI escape sequences. Strip them before passing to your NDJSON parser with a small state machine or the `strip-ansi-escapes` crate.
+
+### 2.2 (HIGH IMPACT) Parallelise Quality Gates with Rayon or Threads
+
+```rust
+// src/runner/quality_gates.rs — replace the sequential for loop
+use std::thread;
+
+pub fn run_quality_gates(feedback_loops: &FeedbackLoopsConfig, verbose: bool) -> QualityGateResult {
+    let gates = collect_gates(feedback_loops);
+
+    if gates.is_empty() {
+        println!("\x1b[2mNo quality gates configured.\x1b[0m");
+        return QualityGateResult::new();
+    }
+
+    println!("\n\x1b[1mRunning quality gates in parallel...\x1b[0m\n");
+
+    // Spawn all gates concurrently
+    let handles: Vec<_> = gates
+        .into_iter()
+        .map(|(name, cmd)| {
+            thread::spawn(move || run_single_gate(&name, &cmd, verbose))
+        })
+        .collect();
+
+    let mut result = QualityGateResult::new();
+    for handle in handles {
+        let gate_result = handle.join().expect("gate thread panicked");
+        let status = if gate_result.passed { "\x1b[32m✓\x1b[0m" } else { "\x1b[31m✗\x1b[0m" };
+        println!("  {} {} ({:.1}s)", status, gate_result.name, gate_result.duration_seconds);
+        result.add_gate(gate_result);
+    }
+
+    result
+}
+```
+
+For three typical gates (clippy ~2 s, tests ~5 s, format ~0.5 s), this reduces wall time from **~7.5 s → ~5 s** (limited by the slowest gate).
+
+### 2.3 (HIGH IMPACT) Cache the Tera Template Across Iterations
+
+Move template compilation out of `generate_prompt_with_root` into a `OnceLock` or pass a compiled `Tera` instance through `AfkConfig`:
+
+```rust
+// src/prompt/mod.rs
+use std::sync::OnceLock;
+
+static COMPILED_TEMPLATE: OnceLock<(String, Tera)> = OnceLock::new();
+
+fn get_compiled_tera(template_str: &str) -> Result<&'static Tera, tera::Error> {
+    // Recompile only if template string changed (e.g., user edited custom template)
+    // For simplicity, compile once per process lifetime
+    let (_, tera) = COMPILED_TEMPLATE.get_or_try_init(|| {
+        let mut tera = Tera::default();
+        tera.add_raw_template("prompt", template_str)?;
+        Ok::<_, tera::Error>((template_str.to_string(), tera))
+    })?;
+    Ok(tera)
+}
+```
+
+For a 20-iteration session, this eliminates 19 template compilations.
+
+### 2.4 (MEDIUM IMPACT) Parallelise Source Loading
+
+```rust
+// src/sources/mod.rs
+use std::thread;
+
+pub fn aggregate_tasks(sources: &[SourceConfig]) -> Vec<UserStory> {
+    if sources.len() <= 1 {
+        return sources.iter().flat_map(load_from_source).collect();
+    }
+
+    let handles: Vec<_> = sources
+        .iter()
+        .cloned()
+        .map(|source| thread::spawn(move || load_from_source(&source)))
+        .collect();
+
+    handles
+        .into_iter()
+        .flat_map(|h| h.join().unwrap_or_default())
+        .collect()
+}
+```
+
+When using beads + GitHub + JSON simultaneously, this turns three sequential process/network calls into one parallel batch.
+
+### 2.5 (MEDIUM IMPACT) Reduce Disk I/O in the Hot Loop
+
+The main loop reads `tasks.json` twice per iteration. Introduce a simple change-detection mechanism using the file's last-modified timestamp:
+
+```rust
+// src/runner/controller.rs
+use std::time::SystemTime;
+
+struct PrdCache {
+    prd: PrdDocument,
+    last_modified: SystemTime,
+    path: PathBuf,
+}
+
+impl PrdCache {
+    fn refresh_if_changed(&mut self) -> &PrdDocument {
+        let mtime = fs::metadata(&self.path)
+            .and_then(|m| m.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+
+        if mtime > self.last_modified {
+            if let Ok(prd) = PrdDocument::load(Some(&self.path)) {
+                self.prd = prd;
+                self.last_modified = mtime;
+            }
+        }
+        &self.prd
+    }
+}
+```
+
+This replaces `PrdDocument::load(None)` in the loop with a stat + conditional read, reducing the common case from a full JSON parse to a single `stat()` syscall.
+
+### 2.6 (MEDIUM IMPACT) Switch Output Buffer to a Single Growing String
+
+```rust
+// src/runner/iteration.rs — replace Vec<String> accumulator
+let mut output = String::with_capacity(64 * 1024); // 64 KB initial capacity
+
+// In the loop, replace:
+//   output_buffer.push(format!("{line}\n"));
+// With:
+output.push_str(&line);
+output.push('\n');
+
+// Remove the final:
+//   let output = output_buffer.concat();
+// `output` is already the complete string
+```
+
+This eliminates `O(N)` small allocations for an `N`-line response, replacing them with amortised `O(1)` growth of a single buffer.
+
+### 2.7 (MEDIUM IMPACT) Git Worktrees for Parallel Task Execution
+
+For projects where tasks are independent (e.g., different feature areas), `afk` could run multiple AI CLI instances simultaneously, each in its own git worktree:
+
+```rust
+// New module: src/runner/worktree.rs
+use std::process::Command;
+use std::path::PathBuf;
+
+pub struct WorktreeGuard {
+    pub path: PathBuf,
+    branch: String,
+}
+
+impl WorktreeGuard {
+    /// Create a new worktree at `<project>/.afk/worktrees/<branch>`.
+    pub fn create(branch: &str, base_branch: &str) -> Result<Self, anyhow::Error> {
+        let path = PathBuf::from(format!(".afk/worktrees/{}", branch));
+        std::fs::create_dir_all(&path)?;
+
+        Command::new("git")
+            .args(["worktree", "add", "-b", branch, path.to_str().unwrap(), base_branch])
+            .status()?;
+
+        Ok(Self { path, branch: branch.to_string() })
+    }
+}
+
+impl Drop for WorktreeGuard {
+    fn drop(&mut self) {
+        let _ = Command::new("git")
+            .args(["worktree", "remove", "--force", self.path.to_str().unwrap()])
+            .status();
+        let _ = Command::new("git")
+            .args(["branch", "-D", &self.branch])
+            .status();
+    }
+}
+```
+
+A parallel runner would:
+1. Split the pending task list across N worktrees
+2. Run one `afk` iteration per worktree concurrently
+3. Merge branches back (or open PRs) on completion
+
+This is the most impactful option for large task lists, but requires careful conflict resolution. Start with independent tasks (e.g., tasks tagged `parallel-safe`).
+
+**Example orchestration sketch:**
+
+```rust
+// src/runner/parallel.rs
+pub fn run_parallel(config: &AfkConfig, tasks: Vec<UserStory>, degree: usize) -> Vec<RunResult> {
+    let chunks: Vec<_> = tasks.chunks(tasks.len().div_ceil(degree)).collect();
+
+    let handles: Vec<_> = chunks
+        .into_iter()
+        .enumerate()
+        .map(|(i, chunk)| {
+            let branch = format!("afk-parallel-{i}-{}", chrono::Utc::now().timestamp());
+            let guard = WorktreeGuard::create(&branch, "main").expect("worktree create failed");
+            let config = config.clone();
+            let tasks = chunk.to_vec();
+
+            std::thread::spawn(move || {
+                let _guard = guard; // keep alive; drop removes worktree
+                run_iteration_in_dir(&config, &tasks, &guard.path)
+            })
+        })
+        .collect();
+
+    handles.into_iter().map(|h| h.join().unwrap()).collect()
+}
+```
+
+### 2.8 (LOW IMPACT) Eliminate the Blocking reqwest Runtime
+
+Replace the blocking reqwest usage in `cli/update.rs` with an async call, or restructure so the binary only has one Tokio runtime:
+
+```toml
+# Cargo.toml — remove "blocking" feature
+reqwest = { version = "0.12", features = ["json"] }
+```
+
+```rust
+// Use tokio::spawn / async fn for the update check
+// or run the check lazily after the main loop completes
+```
+
+This reduces startup overhead by avoiding the creation of a second hidden thread pool.
+
+### 2.9 (LOW IMPACT) Pre-size HashMaps with Known Capacity
+
+```rust
+// src/prompt/mod.rs — pre-size to avoid rehashing
+let gate_count = [
+    config.feedback_loops.types.is_some(),
+    config.feedback_loops.lint.is_some(),
+    config.feedback_loops.test.is_some(),
+    config.feedback_loops.build.is_some(),
+].iter().filter(|&&b| b).count() + config.feedback_loops.custom.len();
+
+let mut feedback_loops: HashMap<String, String> = HashMap::with_capacity(gate_count);
+```
+
+### 2.10 (LOW IMPACT) Deduplicate Streaming Logic
+
+`controller.rs` (`run_iteration_with_tui`) and `iteration.rs` (`execute_command`) contain near-identical output streaming loops. Merging them into a single `stream_output` function with a trait-based sink reduces binary size, compile time, and maintenance burden:
+
+```rust
+trait OutputSink: Send {
+    fn on_line(&mut self, display: Option<String>, tui: Option<TuiEvent>);
+}
+
+struct ConsoleSink<'a>(&'a mut OutputHandler);
+struct TuiSink(mpsc::Sender<TuiEvent>);
+
+fn stream_output(
+    stdout: impl Read,
+    parser: Option<&mut StreamJsonParser>,
+    sink: &mut dyn OutputSink,
+) -> (bool, String) { /* unified streaming logic */ }
+```
+
+---
+
+## 3. Prioritised Next Steps
+
+| Priority | Change | Estimated Speedup | Effort |
+|----------|--------|-------------------|--------|
+| **P0** | PTY-based subprocess spawning (2.1) | Eliminates buffering latency; unlocks AI CLI streaming features | Medium (2–3 days) |
+| **P0** | Parallel quality gates (2.2) | Saves `(N-1)` × avg gate time per iteration | Low (1 day) |
+| **P1** | Cache compiled Tera template (2.3) | Removes template re-parse overhead on every iteration | Low (half day) |
+| **P1** | Reduce hot-loop disk I/O via mtime cache (2.5) | Replaces 2 JSON parses per iteration with `stat()` | Low (1 day) |
+| **P1** | Single-string output buffer (2.6) | Reduces allocator pressure for large AI responses | Low (hours) |
+| **P2** | Parallel source loading (2.4) | Cuts source sync time when using multiple adapters | Low (1 day) |
+| **P2** | Git worktrees for parallel task execution (2.7) | Can achieve N× throughput for independent tasks | High (1–2 weeks) |
+| **P3** | Deduplicate streaming logic (2.10) | Compile-time improvement; correctness benefit | Medium (2–3 days) |
+| **P3** | Async reqwest (2.8) | Removes hidden runtime overhead | Low (hours) |
+| **P3** | Pre-size HashMaps (2.9) | Micro-optimisation | Low (minutes) |
+
+---
+
+## 4. Quick Win Checklist
+
+These changes require < 30 minutes each and have no risk:
+
+- [ ] Replace `Vec<String>` output buffer with `String::with_capacity(64 * 1024)`
+- [ ] Add `HashMap::with_capacity` to feedback loops builder
+- [ ] Extract `run_single_gate` calls into `thread::spawn` joinset
+- [ ] Wrap `Tera` in `OnceLock` to avoid re-compilation
+
+---
+
+## 5. Measurement Plan
+
+Before and after each change, benchmark with:
+
+```bash
+# Startup to first AI CLI spawn (use a no-op AI CLI mock)
+hyperfine --warmup 3 'afk go --dry-run'
+
+# Full iteration wall time (with a fast mock AI CLI that returns immediately)
+time afk go 1
+
+# Quality gate parallel speedup
+hyperfine 'afk verify'
+```
+
+Add `criterion` benchmarks for `generate_prompt_with_root` and `aggregate_tasks` to track regressions in CI.
+
+---
+
+## References
+
+- [`portable-pty`](https://crates.io/crates/portable-pty) — cross-platform PTY support
+- [`strip-ansi-escapes`](https://crates.io/crates/strip-ansi-escapes) — ANSI escape stripping
+- [`rayon`](https://crates.io/crates/rayon) — data parallelism for Rust iterators
+- [Git worktrees documentation](https://git-scm.com/docs/git-worktree)
+- [Tera template caching patterns](https://tera.netlify.app/docs/#global-functions)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -106,6 +106,7 @@ Quality gates (feedback loops) run after each task completion:
 ```
 
 The AI auto-commits only when all gates pass.
+When multiple gates are configured, afk executes them in parallel and reports per-gate status.
 
 ### Learnings
 
@@ -452,6 +453,8 @@ afk use --list       # Show all known CLIs with install status
 
 **Note:** afk automatically appends streaming output flags (`--output-format stream-json`) for supported CLIs. The `args` above are the base configuration only. To disable streaming, set `"output_format": "text"` in your config.
 
+**Optional PTY mode:** if afk is built with `--features pty`, AI CLIs are spawned under a pseudo-terminal (PTY) with ANSI stripping before parsing. This can improve streaming behaviour for some CLIs.
+
 ### Multi-Model Rotation
 
 Configure multiple models to rotate between them pseudo-randomly across iterations. Different models bring different strengths and problem-solving approaches - cycling through them helps avoid getting stuck in local optima.
@@ -664,5 +667,8 @@ curl -fsSL https://raw.githubusercontent.com/m0nkmaster/afk/main/scripts/install
 # From source
 git clone https://github.com/m0nkmaster/afk.git && cd afk
 cargo build --release
+
+# Optional: PTY-based AI spawning
+cargo build --release --features pty
 # Binary at target/release/afk
 ```

--- a/examples/pty_spike.rs
+++ b/examples/pty_spike.rs
@@ -55,7 +55,10 @@ fn main() {
     cmd.arg("--output-format");
     cmd.arg("stream-json");
 
-    println!("Spawning: claude --dangerously-skip-permissions -p \"{}\" --output-format stream-json", prompt);
+    println!(
+        "Spawning: claude --dangerously-skip-permissions -p \"{}\" --output-format stream-json",
+        prompt
+    );
     println!();
 
     // Spawn on the slave side
@@ -83,7 +86,10 @@ fn main() {
         Ok(n) => println!("Read {n} raw bytes from PTY"),
         Err(e) => {
             // PTY read may return an error when the child exits — that's normal.
-            println!("PTY read ended with: {e} ({} bytes captured)", raw_bytes.len());
+            println!(
+                "PTY read ended with: {e} ({} bytes captured)",
+                raw_bytes.len()
+            );
         }
     }
 
@@ -124,8 +130,7 @@ fn main() {
         }
 
         let trimmed = line.trim();
-        let looks_like_json =
-            trimmed.starts_with('{') && trimmed.ends_with('}');
+        let looks_like_json = trimmed.starts_with('{') && trimmed.ends_with('}');
 
         if looks_like_json {
             match serde_json::from_str::<serde_json::Value>(trimmed) {

--- a/examples/pty_spike.rs
+++ b/examples/pty_spike.rs
@@ -1,0 +1,172 @@
+//! PTY Validation Spike
+//!
+//! Spawns the claude CLI under a PTY, strips ANSI escape sequences, and
+//! checks whether each output line is valid JSON. This is the primary
+//! validation artifact for Phase 6.
+//!
+//! Run:
+//!   cargo run --example pty_spike --features pty
+//!
+//! Outputs:
+//!   pty_raw.log      — raw bytes from PTY master
+//!   pty_stripped.log  — after ANSI stripping
+//!   Console report   — line counts and parse results
+
+#[cfg(not(feature = "pty"))]
+fn main() {
+    eprintln!("This example requires the `pty` feature:");
+    eprintln!("  cargo run --example pty_spike --features pty");
+    std::process::exit(1);
+}
+
+#[cfg(feature = "pty")]
+fn main() {
+    use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+    use std::io::{BufRead, BufReader, Read, Write};
+
+    let prompt = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "Say hello in one sentence.".to_string());
+
+    println!("=== PTY Validation Spike ===");
+    println!("Prompt: {prompt}");
+    println!();
+
+    // Open a PTY pair
+    let pty_system = native_pty_system();
+    let pair = match pty_system.openpty(PtySize {
+        rows: 50,
+        cols: 220,
+        pixel_width: 0,
+        pixel_height: 0,
+    }) {
+        Ok(pair) => pair,
+        Err(e) => {
+            eprintln!("Failed to open PTY: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    // Build the claude command
+    let mut cmd = CommandBuilder::new("claude");
+    cmd.arg("--dangerously-skip-permissions");
+    cmd.arg("-p");
+    cmd.arg(&prompt);
+    cmd.arg("--output-format");
+    cmd.arg("stream-json");
+
+    println!("Spawning: claude --dangerously-skip-permissions -p \"{}\" --output-format stream-json", prompt);
+    println!();
+
+    // Spawn on the slave side
+    let mut child = match pair.slave.spawn_command(cmd) {
+        Ok(child) => child,
+        Err(e) => {
+            eprintln!("Failed to spawn command: {e}");
+            std::process::exit(1);
+        }
+    };
+    drop(pair.slave);
+
+    // Read raw output from the master
+    let mut raw_reader = match pair.master.try_clone_reader() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Failed to clone PTY reader: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let mut raw_bytes = Vec::new();
+    let read_result = raw_reader.read_to_end(&mut raw_bytes);
+    match read_result {
+        Ok(n) => println!("Read {n} raw bytes from PTY"),
+        Err(e) => {
+            // PTY read may return an error when the child exits — that's normal.
+            println!("PTY read ended with: {e} ({} bytes captured)", raw_bytes.len());
+        }
+    }
+
+    // Save raw output
+    if let Ok(mut f) = std::fs::File::create("pty_raw.log") {
+        let _ = f.write_all(&raw_bytes);
+        println!("Saved raw output to pty_raw.log");
+    }
+
+    // Strip ANSI
+    let stripped_bytes = strip_ansi_escapes::strip(&raw_bytes);
+    if let Ok(mut f) = std::fs::File::create("pty_stripped.log") {
+        let _ = f.write_all(&stripped_bytes);
+        println!("Saved stripped output to pty_stripped.log");
+    }
+
+    // Parse lines and attempt JSON validation
+    let stripped_text = String::from_utf8_lossy(&stripped_bytes);
+    let reader = BufReader::new(stripped_text.as_bytes());
+
+    let mut total_lines = 0;
+    let mut empty_lines = 0;
+    let mut json_ok = 0;
+    let mut json_fail = 0;
+    let mut plain_text = 0;
+    let mut failures: Vec<(usize, String)> = Vec::new();
+
+    for (i, line) in reader.lines().enumerate() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        total_lines += 1;
+
+        if line.trim().is_empty() {
+            empty_lines += 1;
+            continue;
+        }
+
+        let trimmed = line.trim();
+        let looks_like_json =
+            trimmed.starts_with('{') && trimmed.ends_with('}');
+
+        if looks_like_json {
+            match serde_json::from_str::<serde_json::Value>(trimmed) {
+                Ok(_) => json_ok += 1,
+                Err(_) => {
+                    json_fail += 1;
+                    if failures.len() < 10 {
+                        failures.push((i + 1, line.clone()));
+                    }
+                }
+            }
+        } else {
+            plain_text += 1;
+        }
+    }
+
+    // Wait for child
+    let exit_ok = child.wait().map(|s| s.success()).unwrap_or(false);
+
+    // Report
+    println!();
+    println!("=== Results ===");
+    println!("Child exited successfully: {exit_ok}");
+    println!("Total lines:    {total_lines}");
+    println!("  Empty:        {empty_lines}");
+    println!("  Valid JSON:   {json_ok}");
+    println!("  Invalid JSON: {json_fail}");
+    println!("  Plain text:   {plain_text}");
+    println!();
+
+    if failures.is_empty() && json_ok > 0 {
+        println!("PASS: All JSON-shaped lines parsed successfully.");
+    } else if json_fail > 0 {
+        println!("FAIL: {json_fail} JSON-shaped lines failed to parse.");
+        println!();
+        println!("Sample failures:");
+        for (line_num, content) in &failures {
+            println!("  Line {line_num}: {}", &content[..content.len().min(120)]);
+        }
+    } else if json_ok == 0 {
+        println!("INCONCLUSIVE: No JSON-shaped lines found in output.");
+        println!("The CLI may not be producing stream-json output under PTY.");
+    }
+}

--- a/examples/pty_spike.rs
+++ b/examples/pty_spike.rs
@@ -23,6 +23,33 @@ fn main() {
 fn main() {
     use portable_pty::{native_pty_system, CommandBuilder, PtySize};
     use std::io::{BufRead, BufReader, Read, Write};
+    use vte::{Parser, Perform};
+
+    /// Collects printable output while discarding ANSI control sequences.
+    /// Same approach as the production `AnsiStrippingReader` in `pty_spawn.rs`.
+    #[derive(Default)]
+    struct StripAnsi {
+        out: Vec<u8>,
+    }
+
+    impl Perform for StripAnsi {
+        fn print(&mut self, c: char) {
+            let mut buf = [0u8; 4];
+            self.out
+                .extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+        }
+        fn execute(&mut self, byte: u8) {
+            if matches!(byte, b'\n' | b'\r' | b'\t') {
+                self.out.push(byte);
+            }
+        }
+        fn hook(&mut self, _: &vte::Params, _: &[u8], _: bool, _: char) {}
+        fn put(&mut self, _: u8) {}
+        fn unhook(&mut self) {}
+        fn osc_dispatch(&mut self, _: &[&[u8]], _: bool) {}
+        fn csi_dispatch(&mut self, _: &vte::Params, _: &[u8], _: bool, _: char) {}
+        fn esc_dispatch(&mut self, _: &[u8], _: bool, _: u8) {}
+    }
 
     let prompt = std::env::args()
         .nth(1)
@@ -99,8 +126,11 @@ fn main() {
         println!("Saved raw output to pty_raw.log");
     }
 
-    // Strip ANSI
-    let stripped_bytes = strip_ansi_escapes::strip(&raw_bytes);
+    // Strip ANSI using vte (same stateful parser as production pty_spawn.rs)
+    let mut parser = Parser::new();
+    let mut performer = StripAnsi::default();
+    parser.advance(&mut performer, &raw_bytes);
+    let stripped_bytes = performer.out;
     if let Ok(mut f) = std::fs::File::create("pty_stripped.log") {
         let _ = f.write_all(&stripped_bytes);
         println!("Saved stripped output to pty_stripped.log");

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -1,14 +1,15 @@
 //! Self-update functionality.
 //!
 //! This module handles checking for updates and downloading new versions
-//! of the afk binary from GitHub releases.
+//! of the afk binary from GitHub releases. HTTP requests use async reqwest
+//! with a lightweight tokio runtime at the call boundary.
 
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, Write};
 use std::path::PathBuf;
 
-use reqwest::blocking::Client;
+use reqwest::Client;
 use serde::Deserialize;
 
 /// GitHub repository for releases.
@@ -129,23 +130,25 @@ fn create_client() -> Result<Client, UpdateError> {
 }
 
 /// Get the latest release from GitHub that has binaries for this platform.
-fn get_latest_release(client: &Client, include_prerelease: bool) -> Result<Release, UpdateError> {
+async fn get_latest_release(
+    client: &Client,
+    include_prerelease: bool,
+) -> Result<Release, UpdateError> {
     let url = format!("{}/{}/releases", GITHUB_API_URL, GITHUB_REPO);
 
-    let http_response = client.get(&url).send()?;
+    let http_response = client.get(&url).send().await?;
 
     // Check for rate limiting before trying to parse
     if http_response.status() == reqwest::StatusCode::FORBIDDEN {
         // Check if it's a rate limit error
-        if let Ok(text) = http_response.text() {
-            if text.contains("rate limit") {
-                return Err(UpdateError::RateLimited);
-            }
+        let text = http_response.text().await?;
+        if text.contains("rate limit") {
+            return Err(UpdateError::RateLimited);
         }
         return Err(UpdateError::NoReleaseFound);
     }
 
-    let response: Vec<Release> = http_response.json()?;
+    let response: Vec<Release> = http_response.json().await?;
 
     let platform_binary = get_platform_binary();
 
@@ -199,9 +202,9 @@ fn is_newer_version(current: &str, new: &str) -> bool {
 }
 
 /// Check for available updates.
-pub fn check_for_updates(include_prerelease: bool) -> Result<UpdateCheckResult, UpdateError> {
+async fn check_for_updates(include_prerelease: bool) -> Result<UpdateCheckResult, UpdateError> {
     let client = create_client()?;
-    let release = get_latest_release(&client, include_prerelease)?;
+    let release = get_latest_release(&client, include_prerelease).await?;
 
     let latest_version = parse_version(&release.tag_name).to_string();
     let update_available = is_newer_version(CURRENT_VERSION, &latest_version);
@@ -220,7 +223,7 @@ pub fn check_for_updates(include_prerelease: bool) -> Result<UpdateCheckResult, 
 }
 
 /// Download and install the update.
-pub fn perform_update(download_url: &str) -> Result<PathBuf, UpdateError> {
+async fn perform_update(download_url: &str) -> Result<PathBuf, UpdateError> {
     // Check if running from pip
     if is_pip_install() {
         return Err(UpdateError::InstalledViaPip);
@@ -237,8 +240,8 @@ pub fn perform_update(download_url: &str) -> Result<PathBuf, UpdateError> {
 
     println!("\x1b[2mDownloading update...\x1b[0m");
 
-    let response = client.get(download_url).send()?;
-    let bytes = response.bytes()?;
+    let response = client.get(download_url).send().await?;
+    let bytes = response.bytes().await?;
 
     {
         let mut file = File::create(&temp_file)?;
@@ -274,8 +277,8 @@ pub fn perform_update(download_url: &str) -> Result<PathBuf, UpdateError> {
     Ok(current_exe)
 }
 
-/// Execute the update command.
-pub fn execute_update(beta: bool, check_only: bool) -> Result<(), UpdateError> {
+/// Execute the update command (async implementation).
+async fn execute_update_async(beta: bool, check_only: bool) -> Result<(), UpdateError> {
     // Check if running from pip
     if is_pip_install() && !check_only {
         println!("\x1b[33mNote:\x1b[0m Self-update is not available for pip installations.");
@@ -293,7 +296,7 @@ pub fn execute_update(beta: bool, check_only: bool) -> Result<(), UpdateError> {
 
     println!("\x1b[36mℹ\x1b[0m Checking for updates...");
 
-    let result = check_for_updates(beta)?;
+    let result = check_for_updates(beta).await?;
 
     println!(
         "  Current version: \x1b[36m{}\x1b[0m",
@@ -339,7 +342,8 @@ pub fn execute_update(beta: bool, check_only: bool) -> Result<(), UpdateError> {
             .download_url
             .as_ref()
             .expect("download_url must be Some when can_update() is true"),
-    )?;
+    )
+    .await?;
 
     println!();
     println!(
@@ -351,6 +355,18 @@ pub fn execute_update(beta: bool, check_only: bool) -> Result<(), UpdateError> {
     println!("Restart afk to use the new version.");
 
     Ok(())
+}
+
+/// Execute the update command.
+///
+/// Creates a lightweight tokio runtime to run the async HTTP requests.
+pub fn execute_update(beta: bool, check_only: bool) -> Result<(), UpdateError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("failed to create tokio runtime");
+    rt.block_on(execute_update_async(beta, check_only))
 }
 
 #[cfg(test)]

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -6,6 +6,7 @@ pub mod template;
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Mutex;
 use tera::{Context, Tera};
 
 use crate::config::AfkConfig;
@@ -14,6 +15,28 @@ use crate::progress::SessionProgress;
 
 // Re-export key types and functions for convenience.
 pub use template::{get_template, get_template_with_root, DEFAULT_TEMPLATE};
+
+/// Cached Tera template keyed on template content string.
+/// Avoids recompiling the template on every iteration when it hasn't changed.
+static TEMPLATE_CACHE: Mutex<Option<(String, Tera)>> = Mutex::new(None);
+
+/// Render a template using a cached Tera instance, recompiling only when the template changes.
+fn render_with_cached_tera(template_str: &str, context: &Context) -> Result<String, tera::Error> {
+    let mut cache = TEMPLATE_CACHE.lock().unwrap();
+
+    let needs_compile = match cache.as_ref() {
+        Some((cached_key, _)) => cached_key != template_str,
+        None => true,
+    };
+
+    if needs_compile {
+        let mut tera = Tera::default();
+        tera.add_raw_template("prompt", template_str)?;
+        *cache = Some((template_str.to_string(), tera));
+    }
+
+    cache.as_ref().unwrap().1.render("prompt", context)
+}
 
 /// Error type for prompt generation operations.
 #[derive(Debug, thiserror::Error)]
@@ -115,15 +138,31 @@ pub fn generate_prompt_with_root(
         None
     };
 
-    // Increment iteration for tracking
-    let iteration = progress.increment_iteration();
+    // Increment iteration for tracking (skip when all complete to avoid phantom counts)
+    let iteration = if all_complete {
+        progress.iterations
+    } else {
+        progress.increment_iteration()
+    };
 
-    // Save the updated progress
-    let progress_save_path = root.map(|r| r.join(".afk/progress.json"));
-    progress.save(progress_save_path.as_deref())?;
+    // Save the updated progress (skip when all complete — nothing changed)
+    if !all_complete {
+        let progress_save_path = root.map(|r| r.join(".afk/progress.json"));
+        progress.save(progress_save_path.as_deref())?;
+    }
 
     // Build feedback loops dict (filter out None values)
-    let mut feedback_loops: HashMap<String, String> = HashMap::new();
+    let gate_count = [
+        config.feedback_loops.types.is_some(),
+        config.feedback_loops.lint.is_some(),
+        config.feedback_loops.test.is_some(),
+        config.feedback_loops.build.is_some(),
+    ]
+    .iter()
+    .filter(|&&b| b)
+    .count()
+        + config.feedback_loops.custom.len();
+    let mut feedback_loops: HashMap<String, String> = HashMap::with_capacity(gate_count);
     if let Some(ref types_cmd) = config.feedback_loops.types {
         feedback_loops.insert("types".to_string(), types_cmd.clone());
     }
@@ -143,10 +182,6 @@ pub fn generate_prompt_with_root(
 
     // Get template
     let template_str = get_template_with_root(config, root);
-
-    // Set up Tera and render
-    let mut tera = Tera::default();
-    tera.add_raw_template("prompt", &template_str)?;
 
     // Get next story for context
     let next_story: Option<NextStoryContext> = pending_stories.first().map(|s| NextStoryContext {
@@ -168,7 +203,7 @@ pub fn generate_prompt_with_root(
     context.insert("stop_signal", &stop_signal);
     context.insert("has_frontend", &config.prompt.has_frontend);
 
-    let prompt = tera.render("prompt", &context)?;
+    let prompt = render_with_cached_tera(&template_str, &context)?;
 
     Ok(PromptResult {
         prompt,
@@ -721,5 +756,45 @@ mod tests {
         let json = serde_json::to_string(&next_story).unwrap();
         assert!(json.contains("test-123"));
         assert!(json.contains("2"));
+    }
+
+    #[test]
+    fn test_generate_prompt_no_increment_when_all_complete() {
+        let temp = TempDir::new().unwrap();
+        let (progress_path, tasks_path) = setup_test_env(&temp);
+
+        // Create progress with 5 iterations
+        let mut progress = SessionProgress::new();
+        progress.iterations = 5;
+        progress.save(Some(&progress_path)).unwrap();
+
+        // All stories complete
+        let prd = PrdDocument {
+            user_stories: vec![
+                UserStory {
+                    id: "story-1".to_string(),
+                    passes: true,
+                    ..Default::default()
+                },
+                UserStory {
+                    id: "story-2".to_string(),
+                    passes: true,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        prd.save(Some(&tasks_path)).unwrap();
+
+        let config = AfkConfig::default();
+        let result = generate_prompt_with_root(&config, false, None, Some(temp.path())).unwrap();
+
+        assert!(result.all_complete);
+        // Should NOT have incremented from 5 to 6
+        assert_eq!(result.iteration, 5);
+
+        // Verify progress file was not updated
+        let loaded_progress = SessionProgress::load(Some(&progress_path)).unwrap();
+        assert_eq!(loaded_progress.iterations, 5);
     }
 }

--- a/src/runner/controller.rs
+++ b/src/runner/controller.rs
@@ -926,9 +926,9 @@ fn run_iteration_with_tui(
     tx: std::sync::mpsc::Sender<crate::tui::TuiEvent>,
     interrupted: Arc<AtomicBool>,
 ) -> super::iteration::IterationResult {
+    use super::output_sink::{stream_subprocess_output, TuiSink};
     use crate::parser::StreamJsonParser;
     use crate::prompt::generate_prompt_with_root;
-    use super::output_sink::{stream_subprocess_output, TuiSink};
 
     // Generate prompt
     let prompt = match generate_prompt_with_root(config, true, None, None) {
@@ -966,7 +966,10 @@ fn run_iteration_with_tui(
     };
 
     let mut output = String::with_capacity(64 * 1024);
-    let mut sink = TuiSink { tx: tx.clone(), interrupted };
+    let mut sink = TuiSink {
+        tx: tx.clone(),
+        interrupted,
+    };
 
     #[cfg(feature = "pty")]
     {
@@ -1055,7 +1058,9 @@ fn run_iteration_with_tui(
 
         let stdout = child.stdout.take().expect("stdout was piped");
         let reader: Box<dyn std::io::BufRead> = Box::new(std::io::BufReader::new(stdout));
-        let mut kill = || { let _ = child.kill(); };
+        let mut kill = || {
+            let _ = child.kill();
+        };
         let stream_result = stream_subprocess_output(
             reader,
             &mut kill,

--- a/src/runner/controller.rs
+++ b/src/runner/controller.rs
@@ -37,7 +37,7 @@ impl PrdCache {
     }
 
     /// Return the cached PrdDocument, re-reading from disk only if mtime has changed.
-    fn get(&mut self, fallback: &PrdDocument) -> &PrdDocument {
+    fn get(&mut self) -> &PrdDocument {
         let mtime = std::fs::metadata(&self.path)
             .and_then(|m| m.modified())
             .unwrap_or(SystemTime::UNIX_EPOCH);
@@ -46,9 +46,8 @@ impl PrdCache {
             if let Ok(prd) = PrdDocument::load(None) {
                 self.prd = prd;
                 self.last_modified = mtime;
-            } else {
-                self.prd = fallback.clone();
             }
+            // On load failure, keep self.prd (last known good state)
         }
         &self.prd
     }
@@ -257,7 +256,7 @@ impl LoopController {
             }
 
             // Reload PRD (from cache — only re-reads disk if mtime changed)
-            let mut current_prd = prd_cache.get(prd).clone();
+            let mut current_prd = prd_cache.get().clone();
 
             // Check if all local tasks complete - if so, try to sync more from sources
             if current_prd.all_stories_complete() {
@@ -329,7 +328,7 @@ impl LoopController {
             }
 
             // Check if task was completed (PRD updated by AI CLI)
-            let updated_prd = prd_cache.get(prd).clone();
+            let updated_prd = prd_cache.get().clone();
             let old_completed = current_prd.user_stories.iter().filter(|s| s.passes).count();
             let new_completed = updated_prd.user_stories.iter().filter(|s| s.passes).count();
             if new_completed > old_completed {
@@ -664,7 +663,7 @@ fn run_loop_with_tui_sender(
         }
 
         // Reload PRD (from cache — only re-reads disk if mtime changed)
-        let mut current_prd = prd_cache.get(&prd).clone();
+        let mut current_prd = prd_cache.get().clone();
 
         // Check if all local tasks complete - if so, try to sync more from sources
         if current_prd.all_stories_complete() {
@@ -755,7 +754,7 @@ fn run_loop_with_tui_sender(
         }
 
         // Check if task was completed (PRD updated by AI CLI)
-        let updated_prd = prd_cache.get(&prd).clone();
+        let updated_prd = prd_cache.get().clone();
         let old_completed = current_prd.user_stories.iter().filter(|s| s.passes).count();
         let new_completed = updated_prd.user_stories.iter().filter(|s| s.passes).count();
         if new_completed > old_completed {
@@ -795,25 +794,18 @@ fn run_loop_with_tui_sender(
     }
 }
 
-/// Build and spawn the AI CLI command.
+/// Build command parts and log them to the TUI.
 ///
-#[cfg(not(feature = "pty"))]
-/// Constructs the command with the prompt and output format arguments,
-/// then spawns it as a child process with piped stdout/stderr.
+/// Shared by both PTY and piped spawn paths so command construction
+/// stays in one place.
 ///
-/// If multiple models are configured, one is selected pseudo-randomly
-/// and displayed in the output.
-///
-/// Returns the spawned child process or an error result if spawn fails.
-fn build_ai_command(
+/// Returns `(cmd_parts, selected_model)` or an error if no command is configured.
+fn prepare_ai_command(
     config: &AfkConfig,
-    prompt: &str,
     tx: &std::sync::mpsc::Sender<crate::tui::TuiEvent>,
-) -> Result<std::process::Child, super::iteration::IterationResult> {
+) -> Result<Vec<String>, super::iteration::IterationResult> {
     use crate::tui::TuiEvent;
-    use std::process::{Command, Stdio};
 
-    // Select model upfront so we can display it
     let selected_model = config.ai_cli.select_model().map(|s| s.to_string());
 
     let mut cmd_parts = vec![config.ai_cli.command.clone()];
@@ -829,25 +821,40 @@ fn build_ai_command(
         ));
     }
 
-    let command = &cmd_parts[0];
-    let args: Vec<&str> = cmd_parts[1..].iter().map(|s| s.as_str()).collect();
-
     // Display model selection if multiple models configured
     if config.ai_cli.models.len() > 1 {
         if let Some(ref model) = selected_model {
             let _ = tx.send(TuiEvent::OutputLine(format!(
-                "🎲 Model: {} (1 of {})",
+                "\u{1f3b2} Model: {} (1 of {})",
                 model,
                 config.ai_cli.models.len()
             )));
         }
     }
 
+    let pty_tag = if cfg!(feature = "pty") { " [PTY]" } else { "" };
     let _ = tx.send(TuiEvent::OutputLine(format!(
-        "$ {} {}",
-        command,
-        args.join(" ")
+        "$ {}{}",
+        cmd_parts.join(" "),
+        pty_tag
     )));
+
+    Ok(cmd_parts)
+}
+
+/// Build and spawn the AI CLI command with piped stdout/stderr.
+#[cfg(not(feature = "pty"))]
+fn build_ai_command(
+    config: &AfkConfig,
+    prompt: &str,
+    tx: &std::sync::mpsc::Sender<crate::tui::TuiEvent>,
+) -> Result<std::process::Child, super::iteration::IterationResult> {
+    use std::process::{Command, Stdio};
+
+    let cmd_parts = prepare_ai_command(config, tx)?;
+
+    let command = &cmd_parts[0];
+    let args: Vec<&str> = cmd_parts[1..].iter().map(|s| s.as_str()).collect();
 
     let mut cmd = Command::new(command);
     cmd.args(&args)
@@ -918,7 +925,6 @@ fn wait_for_completion(
     }
 }
 
-/// Check if a line contains a completion signal.
 /// Run a single iteration with TUI output.
 fn run_iteration_with_tui(
     config: &AfkConfig,
@@ -974,35 +980,11 @@ fn run_iteration_with_tui(
     #[cfg(feature = "pty")]
     {
         use super::pty_spawn::PtyProcess;
-        use crate::tui::TuiEvent;
 
-        // Build cmd_parts for PTY spawn (mirrors build_ai_command logic)
-        let selected_model = config.ai_cli.select_model().map(|s| s.to_string());
-        let mut cmd_parts = vec![config.ai_cli.command.clone()];
-        cmd_parts.extend(
-            config
-                .ai_cli
-                .full_args_with_model(selected_model.as_deref()),
-        );
-
-        if cmd_parts.is_empty() {
-            return super::iteration::IterationResult::failure("No command specified");
-        }
-
-        // Log to TUI
-        if config.ai_cli.models.len() > 1 {
-            if let Some(ref model) = selected_model {
-                let _ = tx.send(TuiEvent::OutputLine(format!(
-                    "\u{1f3b2} Model: {} (1 of {})",
-                    model,
-                    config.ai_cli.models.len()
-                )));
-            }
-        }
-        let _ = tx.send(TuiEvent::OutputLine(format!(
-            "$ {} [PTY]",
-            cmd_parts.join(" ")
-        )));
+        let cmd_parts = match prepare_ai_command(config, &tx) {
+            Ok(parts) => parts,
+            Err(result) => return result,
+        };
 
         let mut pty = match PtyProcess::spawn(&cmd_parts, &prompt) {
             Ok(pty) => pty,

--- a/src/runner/controller.rs
+++ b/src/runner/controller.rs
@@ -3,17 +3,56 @@
 //! This module implements the main loop lifecycle, including limits,
 //! stop conditions, and session management.
 
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Instant, SystemTime};
 
 use crate::config::AfkConfig;
 use crate::prd::{mark_story_in_progress, sync_prd_with_root, PrdDocument};
 
 use super::iteration::IterationRunner;
-use super::make_path_relative;
 use super::output_handler::{FeedbackMode, OutputHandler};
 use super::{RunOptions, RunResult, StopReason};
+
+/// Cache for PrdDocument that only re-reads from disk when the file's mtime changes.
+/// Replaces redundant `PrdDocument::load(None)` calls in the hot loop with a single `stat()`.
+struct PrdCache {
+    prd: PrdDocument,
+    last_modified: SystemTime,
+    path: PathBuf,
+}
+
+impl PrdCache {
+    fn new(initial_prd: &PrdDocument) -> Self {
+        let path = PathBuf::from(crate::config::TASKS_FILE);
+        let last_modified = std::fs::metadata(&path)
+            .and_then(|m| m.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        Self {
+            prd: initial_prd.clone(),
+            last_modified,
+            path,
+        }
+    }
+
+    /// Return the cached PrdDocument, re-reading from disk only if mtime has changed.
+    fn get(&mut self, fallback: &PrdDocument) -> &PrdDocument {
+        let mtime = std::fs::metadata(&self.path)
+            .and_then(|m| m.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+
+        if mtime != self.last_modified {
+            if let Ok(prd) = PrdDocument::load(None) {
+                self.prd = prd;
+                self.last_modified = mtime;
+            } else {
+                self.prd = fallback.clone();
+            }
+        }
+        &self.prd
+    }
+}
 
 /// Controls the main loop lifecycle.
 pub struct LoopController {
@@ -190,6 +229,7 @@ impl LoopController {
         let mut iterations_completed: u32 = 0;
         let mut tasks_completed: u32 = 0;
         let stop_reason;
+        let mut prd_cache = PrdCache::new(prd);
 
         let timeout_minutes = timeout_override.unwrap_or(self.config.limits.timeout_minutes);
         let timeout_duration = std::time::Duration::from_secs(timeout_minutes as u64 * 60);
@@ -216,11 +256,8 @@ impl LoopController {
                 break;
             }
 
-            // Reload PRD to check completion
-            let mut current_prd = match PrdDocument::load(None) {
-                Ok(p) => p,
-                Err(_) => prd.clone(),
-            };
+            // Reload PRD (from cache — only re-reads disk if mtime changed)
+            let mut current_prd = prd_cache.get(prd).clone();
 
             // Check if all local tasks complete - if so, try to sync more from sources
             if current_prd.all_stories_complete() {
@@ -291,8 +328,8 @@ impl LoopController {
                 }
             }
 
-            // Check if task was completed (PRD updated)
-            let updated_prd = PrdDocument::load(None).unwrap_or(current_prd.clone());
+            // Check if task was completed (PRD updated by AI CLI)
+            let updated_prd = prd_cache.get(prd).clone();
             let old_completed = current_prd.user_stories.iter().filter(|s| s.passes).count();
             let new_completed = updated_prd.user_stories.iter().filter(|s| s.passes).count();
             if new_completed > old_completed {
@@ -600,6 +637,7 @@ fn run_loop_with_tui_sender(
     let mut iterations_completed: u32 = 0;
     let mut tasks_completed: u32 = 0;
     let stop_reason;
+    let mut prd_cache = PrdCache::new(&prd);
 
     let timeout_minutes = options
         .timeout_minutes
@@ -625,11 +663,8 @@ fn run_loop_with_tui_sender(
             break;
         }
 
-        // Reload PRD to check completion
-        let mut current_prd = match PrdDocument::load(None) {
-            Ok(p) => p,
-            Err(_) => prd.clone(),
-        };
+        // Reload PRD (from cache — only re-reads disk if mtime changed)
+        let mut current_prd = prd_cache.get(&prd).clone();
 
         // Check if all local tasks complete - if so, try to sync more from sources
         if current_prd.all_stories_complete() {
@@ -719,8 +754,8 @@ fn run_loop_with_tui_sender(
             }
         }
 
-        // Check if task was completed
-        let updated_prd = PrdDocument::load(None).unwrap_or(current_prd.clone());
+        // Check if task was completed (PRD updated by AI CLI)
+        let updated_prd = prd_cache.get(&prd).clone();
         let old_completed = current_prd.user_stories.iter().filter(|s| s.passes).count();
         let new_completed = updated_prd.user_stories.iter().filter(|s| s.passes).count();
         if new_completed > old_completed {
@@ -762,6 +797,7 @@ fn run_loop_with_tui_sender(
 
 /// Build and spawn the AI CLI command.
 ///
+#[cfg(not(feature = "pty"))]
 /// Constructs the command with the prompt and output format arguments,
 /// then spawns it as a child process with piped stdout/stderr.
 ///
@@ -837,117 +873,7 @@ fn build_ai_command(
     }
 }
 
-/// Handle a parsed stream event and send appropriate TUI updates.
-///
-/// Processes different event types (messages, tool calls, results) and
-/// sends corresponding TUI events. Returns true if a completion signal
-/// was detected in the event.
-fn handle_stream_event(
-    event: &crate::parser::StreamEvent,
-    tx: &std::sync::mpsc::Sender<crate::tui::TuiEvent>,
-) -> bool {
-    use crate::parser::{StreamEvent, ToolType};
-    use crate::tui::TuiEvent;
-
-    // Check for completion signal only in assistant messages
-    if let StreamEvent::AssistantMessage { ref text } = event {
-        if text.contains("<promise>COMPLETE</promise>")
-            || text.contains("AFK_COMPLETE")
-            || text.contains("AFK_STOP")
-        {
-            let _ = tx.send(TuiEvent::OutputLine(
-                "✓ Completion signal detected".to_string(),
-            ));
-            return true;
-        }
-    }
-
-    match event {
-        StreamEvent::AssistantMessage { text } => {
-            // Truncate long messages for display
-            let display_text = if text.len() > 200 {
-                format!("{}...", &text[..197])
-            } else {
-                text.clone()
-            };
-            let _ = tx.send(TuiEvent::OutputLine(display_text));
-        }
-        StreamEvent::ToolStarted {
-            tool_name,
-            tool_type,
-            path,
-        } => {
-            let path_str = path
-                .as_ref()
-                .map(|p| format!(" {}", make_path_relative(p)))
-                .unwrap_or_default();
-            let _ = tx.send(TuiEvent::OutputLine(format!("→ {}{}", tool_type, path_str)));
-            let _ = tx.send(TuiEvent::ToolCall(tool_name.clone()));
-        }
-        StreamEvent::ToolCompleted {
-            tool_type,
-            path,
-            success,
-            lines,
-            ..
-        } => {
-            let status = if *success { "✓" } else { "✗" };
-            let lines_str = lines.map(|l| format!(" ({} lines)", l)).unwrap_or_default();
-            let path_str = path
-                .as_ref()
-                .map(|p| format!(" {}", make_path_relative(p)))
-                .unwrap_or_default();
-            let _ = tx.send(TuiEvent::OutputLine(format!(
-                "{} {}{}{}",
-                status, tool_type, path_str, lines_str
-            )));
-
-            // Emit file change event for file operations
-            if let Some(p) = path {
-                let change_type = match tool_type {
-                    ToolType::Read => "read",
-                    ToolType::Write => "created",
-                    ToolType::Edit => "modified",
-                    ToolType::Delete => "deleted",
-                    _ => "modified",
-                };
-                let _ = tx.send(TuiEvent::FileChange {
-                    path: make_path_relative(p).to_string(),
-                    change_type: change_type.to_string(),
-                });
-            }
-        }
-        StreamEvent::Result {
-            success,
-            duration_ms,
-            ..
-        } => {
-            let status = if *success {
-                "✓ Complete"
-            } else {
-                "✗ Failed"
-            };
-            let duration_str = duration_ms
-                .map(|ms| format!(" ({:.1}s)", ms as f64 / 1000.0))
-                .unwrap_or_default();
-            let _ = tx.send(TuiEvent::OutputLine(format!("{}{}", status, duration_str)));
-        }
-        StreamEvent::Error { message } => {
-            let _ = tx.send(TuiEvent::Error(message.clone()));
-        }
-        StreamEvent::SystemInit { model, .. } => {
-            if let Some(m) = model {
-                let _ = tx.send(TuiEvent::OutputLine(format!("◉ Model: {}", m)));
-            }
-        }
-        StreamEvent::UserMessage { .. } | StreamEvent::Unknown { .. } => {
-            // Skip these
-        }
-    }
-
-    false
-}
-
+#[cfg(not(feature = "pty"))]
 /// Wait for the AI CLI child process to complete.
 ///
 /// Returns a success result if the process exits cleanly, or a failure
@@ -993,12 +919,6 @@ fn wait_for_completion(
 }
 
 /// Check if a line contains a completion signal.
-fn contains_completion_signal(line: &str) -> bool {
-    line.contains("<promise>COMPLETE</promise>")
-        || line.contains("AFK_COMPLETE")
-        || line.contains("AFK_STOP")
-}
-
 /// Run a single iteration with TUI output.
 fn run_iteration_with_tui(
     config: &AfkConfig,
@@ -1008,8 +928,7 @@ fn run_iteration_with_tui(
 ) -> super::iteration::IterationResult {
     use crate::parser::StreamJsonParser;
     use crate::prompt::generate_prompt_with_root;
-    use crate::tui::TuiEvent;
-    use std::io::{BufRead, BufReader};
+    use super::output_sink::{stream_subprocess_output, TuiSink};
 
     // Generate prompt
     let prompt = match generate_prompt_with_root(config, true, None, None) {
@@ -1039,12 +958,6 @@ fn run_iteration_with_tui(
         };
     }
 
-    // Build and spawn the AI CLI command
-    let mut child = match build_ai_command(config, &prompt, &tx) {
-        Ok(child) => child,
-        Err(result) => return result,
-    };
-
     // Create NDJSON parser if using stream-json format
     let mut stream_parser = if config.ai_cli.uses_stream_json() {
         Some(StreamJsonParser::new(config.ai_cli.detect_cli_format()))
@@ -1052,91 +965,120 @@ fn run_iteration_with_tui(
         None
     };
 
-    // Stream stdout to TUI
-    let mut output_buffer = Vec::new();
-    let mut completion_detected = false;
-    let mut user_interrupted = false;
+    let mut output = String::with_capacity(64 * 1024);
+    let mut sink = TuiSink { tx: tx.clone(), interrupted };
 
-    if let Some(stdout) = child.stdout.take() {
-        let reader = BufReader::new(stdout);
-        for line in reader.lines() {
-            // Check for user interrupt (Q pressed in TUI)
-            if interrupted.load(Ordering::SeqCst) {
-                user_interrupted = true;
-                let _ = child.kill();
-                break;
+    #[cfg(feature = "pty")]
+    {
+        use super::pty_spawn::PtyProcess;
+        use crate::tui::TuiEvent;
+
+        // Build cmd_parts for PTY spawn (mirrors build_ai_command logic)
+        let selected_model = config.ai_cli.select_model().map(|s| s.to_string());
+        let mut cmd_parts = vec![config.ai_cli.command.clone()];
+        cmd_parts.extend(
+            config
+                .ai_cli
+                .full_args_with_model(selected_model.as_deref()),
+        );
+
+        if cmd_parts.is_empty() {
+            return super::iteration::IterationResult::failure("No command specified");
+        }
+
+        // Log to TUI
+        if config.ai_cli.models.len() > 1 {
+            if let Some(ref model) = selected_model {
+                let _ = tx.send(TuiEvent::OutputLine(format!(
+                    "\u{1f3b2} Model: {} (1 of {})",
+                    model,
+                    config.ai_cli.models.len()
+                )));
             }
+        }
+        let _ = tx.send(TuiEvent::OutputLine(format!(
+            "$ {} [PTY]",
+            cmd_parts.join(" ")
+        )));
 
-            match line {
-                Ok(line) => {
-                    // Parse and process based on output format
-                    if let Some(ref mut parser) = stream_parser {
-                        // NDJSON mode: parse and emit events
-                        if let Some(event) = parser.parse_line(&line) {
-                            if handle_stream_event(&event, &tx) {
-                                completion_detected = true;
-                                let _ = child.kill();
-                                break;
-                            }
-                        } else {
-                            // Parsing failed - fall back to raw line display
-                            let _ = tx.send(TuiEvent::OutputLine(line.clone()));
-                            if contains_completion_signal(&line) {
-                                completion_detected = true;
-                                let _ = tx.send(TuiEvent::OutputLine(
-                                    "✓ Completion signal detected".to_string(),
-                                ));
-                                let _ = child.kill();
-                                break;
-                            }
-                        }
-                    } else {
-                        // Plain text mode: send line as-is
-                        let _ = tx.send(TuiEvent::OutputLine(line.clone()));
-
-                        // Track tool calls from output patterns
-                        if line.contains("antml:invoke") || line.contains("<tool_call>") {
-                            let _ = tx.send(TuiEvent::ToolCall("tool".to_string()));
-                        }
-
-                        // Check for completion signal in plain text mode
-                        if contains_completion_signal(&line) {
-                            completion_detected = true;
-                            let _ = tx.send(TuiEvent::OutputLine(
-                                "✓ Completion signal detected".to_string(),
-                            ));
-                            let _ = child.kill();
-                            break;
-                        }
-                    }
-
-                    output_buffer.push(format!("{line}\n"));
-                }
-                Err(e) => {
-                    let _ = tx.send(TuiEvent::Warning(format!("Error reading output: {e}")));
-                    break;
-                }
+        let mut pty = match PtyProcess::spawn(&cmd_parts, &prompt) {
+            Ok(pty) => pty,
+            Err(e) => {
+                return super::iteration::IterationResult::failure(format!(
+                    "Failed to spawn AI CLI via PTY: {e}"
+                ));
             }
+        };
+
+        let reader: Box<dyn std::io::BufRead> = pty.take_reader();
+        let mut kill = || pty.kill();
+        let stream_result = stream_subprocess_output(
+            reader,
+            &mut kill,
+            &mut stream_parser,
+            &mut sink,
+            &mut output,
+        );
+
+        if stream_result.user_interrupted {
+            return super::iteration::IterationResult {
+                success: false,
+                task_id: None,
+                error: Some("User interrupted".to_string()),
+                output,
+            };
+        }
+
+        if stream_result.completion_detected {
+            return super::iteration::IterationResult::success(output);
+        }
+
+        // PTY merges stdout+stderr — just check exit status
+        let exit_ok = pty.wait();
+        if exit_ok {
+            super::iteration::IterationResult::success(output)
+        } else {
+            super::iteration::IterationResult::failure_with_output(
+                "AI CLI exited with non-zero status".to_string(),
+                output,
+            )
         }
     }
 
-    let output = output_buffer.concat();
-
-    if user_interrupted {
-        // User pressed Q in TUI - return gracefully
-        return super::iteration::IterationResult {
-            success: false,
-            task_id: None,
-            error: Some("User interrupted".to_string()),
-            output,
+    #[cfg(not(feature = "pty"))]
+    {
+        // Build and spawn the AI CLI command (piped stdout/stderr)
+        let mut child = match build_ai_command(config, &prompt, &tx) {
+            Ok(child) => child,
+            Err(result) => return result,
         };
-    }
 
-    if completion_detected {
-        return super::iteration::IterationResult::success(output);
-    }
+        let stdout = child.stdout.take().expect("stdout was piped");
+        let reader: Box<dyn std::io::BufRead> = Box::new(std::io::BufReader::new(stdout));
+        let mut kill = || { let _ = child.kill(); };
+        let stream_result = stream_subprocess_output(
+            reader,
+            &mut kill,
+            &mut stream_parser,
+            &mut sink,
+            &mut output,
+        );
 
-    wait_for_completion(child, output)
+        if stream_result.user_interrupted {
+            return super::iteration::IterationResult {
+                success: false,
+                task_id: None,
+                error: Some("User interrupted".to_string()),
+                output,
+            };
+        }
+
+        if stream_result.completion_detected {
+            return super::iteration::IterationResult::success(output);
+        }
+
+        wait_for_completion(child, output)
+    }
 }
 
 /// Sync completed tasks back to their sources.

--- a/src/runner/iteration.rs
+++ b/src/runner/iteration.rs
@@ -397,7 +397,6 @@ impl IterationRunner {
     pub fn output_handler_mut(&mut self) -> &mut OutputHandler {
         &mut self.output
     }
-
 }
 
 /// Run a single iteration with fresh AI context.

--- a/src/runner/iteration.rs
+++ b/src/runner/iteration.rs
@@ -273,7 +273,9 @@ impl IterationRunner {
                             cmd_parts[0]
                         ));
                     }
-                    return IterationResult::failure(format!("Failed to spawn AI CLI via PTY: {e}"));
+                    return IterationResult::failure(format!(
+                        "Failed to spawn AI CLI via PTY: {e}"
+                    ));
                 }
             };
 
@@ -289,7 +291,11 @@ impl IterationRunner {
 
             // PTY merges stdout+stderr — no separate stderr capture
             let exit_ok = pty.wait();
-            (stream_result.completion_detected, String::new(), Ok::<bool, std::io::Error>(exit_ok))
+            (
+                stream_result.completion_detected,
+                String::new(),
+                Ok::<bool, std::io::Error>(exit_ok),
+            )
         };
 
         #[cfg(not(feature = "pty"))]
@@ -320,7 +326,9 @@ impl IterationRunner {
 
             let stdout = child.stdout.take().expect("stdout was piped");
             let reader: Box<dyn std::io::BufRead> = Box::new(BufReader::new(stdout));
-            let mut kill = || { let _ = child.kill(); };
+            let mut kill = || {
+                let _ = child.kill();
+            };
             let stream_result = stream_subprocess_output(
                 reader,
                 &mut kill,
@@ -339,7 +347,11 @@ impl IterationRunner {
             };
 
             let wait_result = child.wait().map(|status| status.success());
-            (stream_result.completion_detected, stderr_output, wait_result)
+            (
+                stream_result.completion_detected,
+                stderr_output,
+                wait_result,
+            )
         };
 
         // Show iteration summary with stats

--- a/src/runner/iteration.rs
+++ b/src/runner/iteration.rs
@@ -3,17 +3,19 @@
 //! This module handles spawning AI CLI, streaming output, and detecting completion signals.
 //! Supports both plain text and NDJSON stream-json output formats.
 
+#[cfg(not(feature = "pty"))]
 use std::io::{BufRead, BufReader};
+#[cfg(not(feature = "pty"))]
 use std::process::{Command, Stdio};
 use std::sync::mpsc::Sender;
 
 use crate::config::AfkConfig;
-use crate::parser::{StreamEvent, StreamJsonParser};
+use crate::parser::StreamJsonParser;
 use crate::prompt::generate_prompt_with_root;
 use crate::tui::TuiEvent;
 
-use super::make_path_relative;
 use super::output_handler::OutputHandler;
+use super::output_sink::{stream_subprocess_output, ConsoleSink};
 
 /// Result of a single iteration.
 #[derive(Debug)]
@@ -237,17 +239,6 @@ impl IterationRunner {
             return IterationResult::failure("No command specified");
         }
 
-        let command = &cmd_parts[0];
-        let args: Vec<&str> = cmd_parts[1..].iter().map(|s| s.as_str()).collect();
-
-        // Build full command with prompt as final argument
-        let mut cmd = Command::new(command);
-        cmd.args(&args)
-            .arg(prompt)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
         // Start feedback display (shows live status)
         self.output.set_iteration_context(
             self.current_iteration,
@@ -257,120 +248,98 @@ impl IterationRunner {
         );
         self.output.start_feedback(None);
 
-        // Spawn process
-        let mut child = match cmd.spawn() {
-            Ok(child) => child,
-            Err(e) => {
-                self.output.stop_feedback();
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    return IterationResult::failure(format!(
-                        "AI CLI not found: {}. Is it installed and in your PATH?",
-                        command
-                    ));
-                }
-                return IterationResult::failure(format!("Failed to spawn AI CLI: {e}"));
-            }
+        // Stream stdout through the unified streaming function
+        let mut output = String::with_capacity(64 * 1024);
+        let mut sink = ConsoleSink {
+            output: &mut self.output,
+            tui_sender: self.tui_sender.as_ref(),
         };
 
-        // Stream stdout
-        let mut output_buffer = Vec::new();
-        let mut completion_detected = false;
+        #[cfg(feature = "pty")]
+        let (completion_detected, stderr_output, wait_result) = {
+            use super::pty_spawn::PtyProcess;
 
-        if let Some(stdout) = child.stdout.take() {
-            let reader = BufReader::new(stdout);
-            for line in reader.lines() {
-                match line {
-                    Ok(line) => {
-                        // Parse and display based on output format
-                        if self.stream_parser.is_some() {
-                            // NDJSON mode: parse and convert to display text
-                            // Falls back to raw line if parsing fails (CLI doesn't support stream-json)
-                            if let Some(ref mut parser) = self.stream_parser {
-                                if let Some(event) = parser.parse_line(&line) {
-                                    // Check for completion signal only in assistant messages
-                                    // (not in user messages which may contain the prompt with examples)
-                                    if let crate::parser::StreamEvent::AssistantMessage {
-                                        ref text,
-                                    } = event
-                                    {
-                                        if self.output.contains_completion_signal(text) {
-                                            completion_detected = true;
-                                            self.output.completion_detected();
-                                            // Terminate the process
-                                            let _ = child.kill();
-                                            break;
-                                        }
-                                    }
-
-                                    // Convert event to display text and emit TUI event
-                                    let (display, tui_event) = self.stream_event_to_display(&event);
-
-                                    // Send TUI event if we have a sender
-                                    if let (Some(ref sender), Some(tui_event)) =
-                                        (&self.tui_sender, tui_event)
-                                    {
-                                        let _ = sender.send(tui_event);
-                                    }
-
-                                    if let Some(display) = display {
-                                        self.output.stream_line(&format!("{display}\n"));
-                                    }
-                                } else {
-                                    // Parsing returned None - check if it's valid JSON we should suppress
-                                    // vs plain text we should display
-                                    let is_json = line.trim_start().starts_with('{')
-                                        && line.trim_end().ends_with('}');
-
-                                    if is_json {
-                                        // Valid JSON but no displayable content - silently skip
-                                        // Still check for completion signals in case they're embedded
-                                        if self.output.contains_completion_signal(&line) {
-                                            completion_detected = true;
-                                            self.output.completion_detected();
-                                            let _ = child.kill();
-                                            break;
-                                        }
-                                    } else {
-                                        // Plain text output - display as-is (fallback for CLIs
-                                        // that don't support stream-json)
-                                        self.output.stream_line(&format!("{line}\n"));
-                                        if self.output.contains_completion_signal(&line) {
-                                            completion_detected = true;
-                                            self.output.completion_detected();
-                                            let _ = child.kill();
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-                        } else {
-                            // Plain text mode: display as-is and check raw line
-                            self.output.stream_line(&format!("{line}\n"));
-                            if self.output.contains_completion_signal(&line) {
-                                completion_detected = true;
-                                self.output.completion_detected();
-                                // Terminate the process
-                                let _ = child.kill();
-                                break;
-                            }
-                        }
-                        output_buffer.push(format!("{line}\n"));
+            let mut pty = match PtyProcess::spawn(cmd_parts, prompt) {
+                Ok(pty) => pty,
+                Err(e) => {
+                    self.output.stop_feedback();
+                    let err_msg = format!("{e}");
+                    if err_msg.contains("No such file")
+                        || err_msg.contains("not found")
+                        || err_msg.contains("not exist")
+                    {
+                        return IterationResult::failure(format!(
+                            "AI CLI not found: {}. Is it installed and in your PATH?",
+                            cmd_parts[0]
+                        ));
                     }
-                    Err(e) => {
-                        self.output.warning(&format!("Error reading output: {e}"));
-                        break;
-                    }
+                    return IterationResult::failure(format!("Failed to spawn AI CLI via PTY: {e}"));
                 }
-            }
-        }
+            };
 
-        // Capture stderr before waiting for process
-        let stderr_output = if let Some(stderr) = child.stderr.take() {
-            let reader = BufReader::new(stderr);
-            let lines: Vec<String> = reader.lines().map_while(Result::ok).collect();
-            lines.join("\n")
-        } else {
-            String::new()
+            let reader: Box<dyn std::io::BufRead> = pty.take_reader();
+            let mut kill = || pty.kill();
+            let stream_result = stream_subprocess_output(
+                reader,
+                &mut kill,
+                &mut self.stream_parser,
+                &mut sink,
+                &mut output,
+            );
+
+            // PTY merges stdout+stderr — no separate stderr capture
+            let exit_ok = pty.wait();
+            (stream_result.completion_detected, String::new(), Ok::<bool, std::io::Error>(exit_ok))
+        };
+
+        #[cfg(not(feature = "pty"))]
+        let (completion_detected, stderr_output, wait_result) = {
+            let command = &cmd_parts[0];
+            let args: Vec<&str> = cmd_parts[1..].iter().map(|s| s.as_str()).collect();
+
+            let mut cmd = Command::new(command);
+            cmd.args(&args)
+                .arg(prompt)
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+
+            let mut child = match cmd.spawn() {
+                Ok(child) => child,
+                Err(e) => {
+                    self.output.stop_feedback();
+                    if e.kind() == std::io::ErrorKind::NotFound {
+                        return IterationResult::failure(format!(
+                            "AI CLI not found: {}. Is it installed and in your PATH?",
+                            command
+                        ));
+                    }
+                    return IterationResult::failure(format!("Failed to spawn AI CLI: {e}"));
+                }
+            };
+
+            let stdout = child.stdout.take().expect("stdout was piped");
+            let reader: Box<dyn std::io::BufRead> = Box::new(BufReader::new(stdout));
+            let mut kill = || { let _ = child.kill(); };
+            let stream_result = stream_subprocess_output(
+                reader,
+                &mut kill,
+                &mut self.stream_parser,
+                &mut sink,
+                &mut output,
+            );
+
+            // Capture stderr before waiting for process
+            let stderr_output = if let Some(stderr) = child.stderr.take() {
+                let reader = BufReader::new(stderr);
+                let lines: Vec<String> = reader.lines().map_while(Result::ok).collect();
+                lines.join("\n")
+            } else {
+                String::new()
+            };
+
+            let wait_result = child.wait().map(|status| status.success());
+            (stream_result.completion_detected, stderr_output, wait_result)
         };
 
         // Show iteration summary with stats
@@ -379,33 +348,26 @@ impl IterationRunner {
         // Stop feedback display
         self.output.stop_feedback();
 
-        let output = output_buffer.concat();
-
         if completion_detected {
             return IterationResult::success(output);
         }
 
-        // Wait for process to finish
-        match child.wait() {
-            Ok(status) => {
-                if !status.success() {
-                    let exit_code = status.code().unwrap_or(-1);
-                    // Include full stderr in error message
-                    let error_msg = if stderr_output.is_empty() {
-                        format!("AI CLI exited with code {exit_code}")
-                    } else {
-                        format!(
-                            "AI CLI exited with code {exit_code}\n\x1b[31m{}\x1b[0m",
-                            stderr_output.trim()
-                        )
-                    };
-                    // Display stderr prominently
-                    if !stderr_output.is_empty() {
-                        self.output.error(&error_msg);
-                    }
-                    return IterationResult::failure_with_output(error_msg, output);
+        // Check process exit status
+        match wait_result {
+            Ok(true) => IterationResult::success(output),
+            Ok(false) => {
+                let error_msg = if stderr_output.is_empty() {
+                    "AI CLI exited with non-zero status".to_string()
+                } else {
+                    format!(
+                        "AI CLI exited with non-zero status\n\x1b[31m{}\x1b[0m",
+                        stderr_output.trim()
+                    )
+                };
+                if !stderr_output.is_empty() {
+                    self.output.error(&error_msg);
                 }
-                IterationResult::success(output)
+                IterationResult::failure_with_output(error_msg, output)
             }
             Err(e) => IterationResult::failure_with_output(
                 format!("Failed to wait for AI CLI: {e}"),
@@ -424,116 +386,6 @@ impl IterationRunner {
         &mut self.output
     }
 
-    /// Convert a StreamEvent to display text and optional TuiEvent.
-    fn stream_event_to_display(&self, event: &StreamEvent) -> (Option<String>, Option<TuiEvent>) {
-        match event {
-            StreamEvent::SystemInit { model, .. } => {
-                let display = model
-                    .as_ref()
-                    .map(|m| format!("\x1b[2m◉ Model: {}\x1b[0m", m));
-                (display, None)
-            }
-            StreamEvent::UserMessage { .. } => {
-                // Don't display user message (it's the prompt we sent)
-                (None, None)
-            }
-            StreamEvent::AssistantMessage { text } => {
-                // Skip empty messages (e.g., tool-use-only content blocks)
-                if text.is_empty() {
-                    return (None, None);
-                }
-                // Truncate very long messages for display
-                let display_text = if text.len() > 200 {
-                    format!("{}...", &text[..197])
-                } else {
-                    text.clone()
-                };
-                let display = format!("\x1b[37m{}\x1b[0m", display_text);
-                let tui_event = TuiEvent::OutputLine(text.clone());
-                (Some(display), Some(tui_event))
-            }
-            StreamEvent::ToolStarted {
-                tool_name,
-                tool_type,
-                path,
-            } => {
-                let path_str = path
-                    .as_ref()
-                    .map(|p| format!(" {}", make_path_relative(p)))
-                    .unwrap_or_default();
-                let display = format!("\x1b[33m→ {}{}\x1b[0m", tool_type, path_str);
-                let tui_event = TuiEvent::ToolCall(tool_name.clone());
-                (Some(display), Some(tui_event))
-            }
-            StreamEvent::ToolCompleted {
-                tool_type,
-                path,
-                success,
-                lines,
-                ..
-            } => {
-                let status = if *success { "✓" } else { "✗" };
-                let lines_str = lines.map(|l| format!(" ({} lines)", l)).unwrap_or_default();
-                let path_str = path
-                    .as_ref()
-                    .map(|p| format!(" {}", make_path_relative(p)))
-                    .unwrap_or_default();
-                let colour = if *success { "\x1b[32m" } else { "\x1b[31m" };
-                let display = format!(
-                    "{}{} {}{}{}\x1b[0m",
-                    colour, status, tool_type, path_str, lines_str
-                );
-
-                // Emit file change event for file operations
-                let tui_event = path.as_ref().map(|p| {
-                    let change_type = match tool_type {
-                        crate::parser::ToolType::Read => "read",
-                        crate::parser::ToolType::Write => "created",
-                        crate::parser::ToolType::Edit => "modified",
-                        crate::parser::ToolType::Delete => "deleted",
-                        _ => "modified",
-                    };
-                    TuiEvent::FileChange {
-                        path: make_path_relative(p).to_string(),
-                        change_type: change_type.to_string(),
-                    }
-                });
-
-                (Some(display), tui_event)
-            }
-            StreamEvent::Result {
-                success,
-                duration_ms,
-                ..
-            } => {
-                let status = if *success {
-                    "✓ Complete"
-                } else {
-                    "✗ Failed"
-                };
-                let duration_str = duration_ms
-                    .map(|ms| format!(" ({:.1}s)", ms as f64 / 1000.0))
-                    .unwrap_or_default();
-                let colour = if *success { "\x1b[32m" } else { "\x1b[31m" };
-                let display = format!("{}{}{}\x1b[0m", colour, status, duration_str);
-
-                let tui_event = duration_ms.map(|ms| TuiEvent::IterationComplete {
-                    duration_secs: ms as f64 / 1000.0,
-                });
-
-                (Some(display), tui_event)
-            }
-            StreamEvent::Error { message } => {
-                let display = format!("\x1b[31m✗ Error: {}\x1b[0m", message);
-                let tui_event = TuiEvent::Error(message.clone());
-                (Some(display), Some(tui_event))
-            }
-            StreamEvent::Unknown { .. } => {
-                // Don't display unknown events
-                (None, None)
-            }
-        }
-    }
 }
 
 /// Run a single iteration with fresh AI context.

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -8,6 +8,9 @@ use std::sync::OnceLock;
 mod controller;
 mod iteration;
 mod output_handler;
+pub(crate) mod output_sink;
+#[cfg(feature = "pty")]
+pub(crate) mod pty_spawn;
 mod quality_gates;
 mod sleep_guard;
 

--- a/src/runner/output_sink.rs
+++ b/src/runner/output_sink.rs
@@ -101,18 +101,8 @@ impl OutputSink for TuiSink {
     fn on_stream_event(&mut self, event: &StreamEvent) {
         use crate::parser::StreamEvent::*;
 
-        // Check for completion signal in assistant messages
-        if let AssistantMessage { ref text } = event {
-            if text.contains("<promise>COMPLETE</promise>")
-                || text.contains("AFK_COMPLETE")
-                || text.contains("AFK_STOP")
-            {
-                let _ = self.tx.send(TuiEvent::OutputLine(
-                    "✓ Completion signal detected".to_string(),
-                ));
-                // Caller handles the kill — we just report
-            }
-        }
+        // Completion signal detection is handled by stream_subprocess_output,
+        // which calls on_completion() and triggers the kill. No need to check here.
 
         match event {
             AssistantMessage { text } => {

--- a/src/runner/output_sink.rs
+++ b/src/runner/output_sink.rs
@@ -1,0 +1,442 @@
+//! Unified output sink trait for streaming AI CLI output.
+//!
+//! This module provides a single streaming implementation shared by both
+//! the console (non-TUI) and TUI code paths, fixing the NDJSON bug where
+//! the TUI path would display raw JSON lines that the console path correctly suppressed.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
+
+use crate::parser::{StreamEvent, ToolType};
+use crate::tui::TuiEvent;
+
+use super::make_path_relative;
+use super::output_handler::OutputHandler;
+
+/// Trait for receiving streaming output from AI CLI subprocesses.
+///
+/// Both the console and TUI rendering paths implement this trait,
+/// allowing `stream_subprocess_output` to work with either.
+pub trait OutputSink {
+    /// Display a line of plain text output.
+    fn on_line(&mut self, line: &str);
+    /// Handle a parsed NDJSON stream event.
+    fn on_stream_event(&mut self, event: &StreamEvent);
+    /// Signal that a completion marker was detected.
+    fn on_completion(&mut self);
+    /// Display a warning message.
+    fn on_warning(&mut self, msg: &str);
+    /// Check if text contains a completion signal.
+    fn contains_completion_signal(&self, text: &str) -> bool;
+    /// Check if the user has requested an interrupt.
+    fn is_interrupted(&self) -> bool;
+}
+
+// ---------------------------------------------------------------------------
+// Console (non-TUI) sink
+// ---------------------------------------------------------------------------
+
+/// Sink that writes to the console via `OutputHandler`.
+/// Optionally forwards TUI events when a sender is present.
+pub struct ConsoleSink<'a> {
+    pub output: &'a mut OutputHandler,
+    pub tui_sender: Option<&'a Sender<TuiEvent>>,
+}
+
+impl OutputSink for ConsoleSink<'_> {
+    fn on_line(&mut self, line: &str) {
+        self.output.stream_line(&format!("{line}\n"));
+    }
+
+    fn on_stream_event(&mut self, event: &StreamEvent) {
+        let (display, tui_event) = stream_event_to_display(event);
+
+        if let (Some(sender), Some(tui_event)) = (self.tui_sender, tui_event) {
+            let _ = sender.send(tui_event);
+        }
+
+        if let Some(display) = display {
+            self.output.stream_line(&format!("{display}\n"));
+        }
+    }
+
+    fn on_completion(&mut self) {
+        self.output.completion_detected();
+    }
+
+    fn on_warning(&mut self, msg: &str) {
+        self.output.warning(msg);
+    }
+
+    fn contains_completion_signal(&self, text: &str) -> bool {
+        self.output.contains_completion_signal(text)
+    }
+
+    fn is_interrupted(&self) -> bool {
+        false // Console path doesn't support TUI interrupts
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TUI sink
+// ---------------------------------------------------------------------------
+
+/// Sink that sends events to the TUI via an `mpsc::Sender`.
+pub struct TuiSink {
+    pub tx: Sender<TuiEvent>,
+    pub interrupted: Arc<AtomicBool>,
+}
+
+impl OutputSink for TuiSink {
+    fn on_line(&mut self, line: &str) {
+        let _ = self.tx.send(TuiEvent::OutputLine(line.to_string()));
+
+        // Track tool calls from output patterns (plain text mode)
+        if line.contains("antml:invoke") || line.contains("<tool_call>") {
+            let _ = self.tx.send(TuiEvent::ToolCall("tool".to_string()));
+        }
+    }
+
+    fn on_stream_event(&mut self, event: &StreamEvent) {
+        use crate::parser::StreamEvent::*;
+
+        // Check for completion signal in assistant messages
+        if let AssistantMessage { ref text } = event {
+            if text.contains("<promise>COMPLETE</promise>")
+                || text.contains("AFK_COMPLETE")
+                || text.contains("AFK_STOP")
+            {
+                let _ = self
+                    .tx
+                    .send(TuiEvent::OutputLine("✓ Completion signal detected".to_string()));
+                // Caller handles the kill — we just report
+            }
+        }
+
+        match event {
+            AssistantMessage { text } => {
+                if text.is_empty() {
+                    return;
+                }
+                let display_text = if text.len() > 200 {
+                    format!("{}...", &text[..197])
+                } else {
+                    text.clone()
+                };
+                let _ = self.tx.send(TuiEvent::OutputLine(display_text));
+            }
+            ToolStarted {
+                tool_name,
+                tool_type,
+                path,
+            } => {
+                let path_str = path
+                    .as_ref()
+                    .map(|p| format!(" {}", make_path_relative(p)))
+                    .unwrap_or_default();
+                let _ = self
+                    .tx
+                    .send(TuiEvent::OutputLine(format!("→ {}{}", tool_type, path_str)));
+                let _ = self.tx.send(TuiEvent::ToolCall(tool_name.clone()));
+            }
+            ToolCompleted {
+                tool_type,
+                path,
+                success,
+                lines,
+                ..
+            } => {
+                let status = if *success { "✓" } else { "✗" };
+                let lines_str = lines.map(|l| format!(" ({} lines)", l)).unwrap_or_default();
+                let path_str = path
+                    .as_ref()
+                    .map(|p| format!(" {}", make_path_relative(p)))
+                    .unwrap_or_default();
+                let _ = self.tx.send(TuiEvent::OutputLine(format!(
+                    "{} {}{}{}",
+                    status, tool_type, path_str, lines_str
+                )));
+
+                if let Some(p) = path {
+                    let change_type = match tool_type {
+                        ToolType::Read => "read",
+                        ToolType::Write => "created",
+                        ToolType::Edit => "modified",
+                        ToolType::Delete => "deleted",
+                        _ => "modified",
+                    };
+                    let _ = self.tx.send(TuiEvent::FileChange {
+                        path: make_path_relative(p).to_string(),
+                        change_type: change_type.to_string(),
+                    });
+                }
+            }
+            Result {
+                success,
+                duration_ms,
+                ..
+            } => {
+                let status = if *success {
+                    "✓ Complete"
+                } else {
+                    "✗ Failed"
+                };
+                let duration_str = duration_ms
+                    .map(|ms| format!(" ({:.1}s)", ms as f64 / 1000.0))
+                    .unwrap_or_default();
+                let _ = self
+                    .tx
+                    .send(TuiEvent::OutputLine(format!("{}{}", status, duration_str)));
+            }
+            Error { message } => {
+                let _ = self.tx.send(TuiEvent::Error(message.clone()));
+            }
+            SystemInit { model, .. } => {
+                if let Some(m) = model {
+                    let _ = self
+                        .tx
+                        .send(TuiEvent::OutputLine(format!("◉ Model: {}", m)));
+                }
+            }
+            UserMessage { .. } | Unknown { .. } => {}
+        }
+    }
+
+    fn on_completion(&mut self) {
+        let _ = self
+            .tx
+            .send(TuiEvent::OutputLine("✓ Completion signal detected".to_string()));
+    }
+
+    fn on_warning(&mut self, msg: &str) {
+        let _ = self
+            .tx
+            .send(TuiEvent::Warning(format!("Warning: {msg}")));
+    }
+
+    fn contains_completion_signal(&self, text: &str) -> bool {
+        text.contains("<promise>COMPLETE</promise>")
+            || text.contains("AFK_COMPLETE")
+            || text.contains("AFK_STOP")
+    }
+
+    fn is_interrupted(&self) -> bool {
+        self.interrupted.load(Ordering::SeqCst)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unified streaming function
+// ---------------------------------------------------------------------------
+
+/// Result of streaming subprocess output.
+pub struct StreamResult {
+    /// Whether a completion signal was detected.
+    pub completion_detected: bool,
+    /// Whether the user interrupted (TUI Q press).
+    pub user_interrupted: bool,
+}
+
+/// Stream stdout from an AI CLI subprocess through an `OutputSink`.
+///
+/// This is the single implementation of the NDJSON + plain-text streaming loop,
+/// shared by both the console and TUI paths. When the parser returns `None` for
+/// a line, JSON-shaped lines are silently suppressed (fixing the TUI bug where
+/// raw NDJSON was forwarded to the display).
+pub fn stream_subprocess_output(
+    reader: Box<dyn std::io::BufRead>,
+    kill_fn: &mut dyn FnMut(),
+    parser: &mut Option<crate::parser::StreamJsonParser>,
+    sink: &mut dyn OutputSink,
+    output_buf: &mut String,
+) -> StreamResult {
+    use std::io::BufRead;
+
+    let mut completion_detected = false;
+    let mut user_interrupted = false;
+
+    for line in reader.lines() {
+        // Check for user interrupt
+        if sink.is_interrupted() {
+            user_interrupted = true;
+            kill_fn();
+            break;
+        }
+
+        match line {
+            Ok(line) => {
+                if let Some(ref mut p) = parser {
+                    // NDJSON mode
+                    if let Some(event) = p.parse_line(&line) {
+                        // Check for completion signal in assistant messages
+                        if let StreamEvent::AssistantMessage { ref text } = event {
+                            if sink.contains_completion_signal(text) {
+                                completion_detected = true;
+                                sink.on_completion();
+                                kill_fn();
+                                break;
+                            }
+                        }
+
+                        sink.on_stream_event(&event);
+                    } else {
+                        // Parser returned None — decide whether to display or suppress.
+                        // JSON-shaped lines are suppressed (they're NDJSON metadata);
+                        // plain text is displayed (fallback for CLIs without stream-json).
+                        let is_json = line.trim_start().starts_with('{')
+                            && line.trim_end().ends_with('}');
+
+                        if is_json {
+                            // Silently skip, but still check for embedded completion signals
+                            if sink.contains_completion_signal(&line) {
+                                completion_detected = true;
+                                sink.on_completion();
+                                kill_fn();
+                                break;
+                            }
+                        } else {
+                            // Plain text fallback — display as-is
+                            sink.on_line(&line);
+                            if sink.contains_completion_signal(&line) {
+                                completion_detected = true;
+                                sink.on_completion();
+                                kill_fn();
+                                break;
+                            }
+                        }
+                    }
+                } else {
+                    // Plain text mode — display every line
+                    sink.on_line(&line);
+                    if sink.contains_completion_signal(&line) {
+                        completion_detected = true;
+                        sink.on_completion();
+                        kill_fn();
+                        break;
+                    }
+                }
+
+                output_buf.push_str(&line);
+                output_buf.push('\n');
+            }
+            Err(e) => {
+                sink.on_warning(&format!("Error reading output: {e}"));
+                break;
+            }
+        }
+    }
+
+    StreamResult {
+        completion_detected,
+        user_interrupted,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helper for console event display (extracted from iteration.rs)
+// ---------------------------------------------------------------------------
+
+/// Convert a StreamEvent to a display string and optional TuiEvent.
+///
+/// Used by `ConsoleSink` — the TUI sink handles events directly.
+fn stream_event_to_display(event: &StreamEvent) -> (Option<String>, Option<TuiEvent>) {
+    match event {
+        StreamEvent::SystemInit { model, .. } => {
+            let display = model
+                .as_ref()
+                .map(|m| format!("\x1b[2m◉ Model: {}\x1b[0m", m));
+            (display, None)
+        }
+        StreamEvent::UserMessage { .. } => (None, None),
+        StreamEvent::AssistantMessage { text } => {
+            if text.is_empty() {
+                return (None, None);
+            }
+            let display_text = if text.len() > 200 {
+                format!("{}...", &text[..197])
+            } else {
+                text.clone()
+            };
+            let display = format!("\x1b[37m{}\x1b[0m", display_text);
+            let tui_event = TuiEvent::OutputLine(text.clone());
+            (Some(display), Some(tui_event))
+        }
+        StreamEvent::ToolStarted {
+            tool_name,
+            tool_type,
+            path,
+        } => {
+            let path_str = path
+                .as_ref()
+                .map(|p| format!(" {}", make_path_relative(p)))
+                .unwrap_or_default();
+            let display = format!("\x1b[33m→ {}{}\x1b[0m", tool_type, path_str);
+            let tui_event = TuiEvent::ToolCall(tool_name.clone());
+            (Some(display), Some(tui_event))
+        }
+        StreamEvent::ToolCompleted {
+            tool_type,
+            path,
+            success,
+            lines,
+            ..
+        } => {
+            let status = if *success { "✓" } else { "✗" };
+            let lines_str = lines.map(|l| format!(" ({} lines)", l)).unwrap_or_default();
+            let path_str = path
+                .as_ref()
+                .map(|p| format!(" {}", make_path_relative(p)))
+                .unwrap_or_default();
+            let colour = if *success { "\x1b[32m" } else { "\x1b[31m" };
+            let display = format!(
+                "{}{} {}{}{}\x1b[0m",
+                colour, status, tool_type, path_str, lines_str
+            );
+
+            let tui_event = path.as_ref().map(|p| {
+                let change_type = match tool_type {
+                    ToolType::Read => "read",
+                    ToolType::Write => "created",
+                    ToolType::Edit => "modified",
+                    ToolType::Delete => "deleted",
+                    _ => "modified",
+                };
+                TuiEvent::FileChange {
+                    path: make_path_relative(p).to_string(),
+                    change_type: change_type.to_string(),
+                }
+            });
+
+            (Some(display), tui_event)
+        }
+        StreamEvent::Result {
+            success,
+            duration_ms,
+            ..
+        } => {
+            let status = if *success {
+                "✓ Complete"
+            } else {
+                "✗ Failed"
+            };
+            let duration_str = duration_ms
+                .map(|ms| format!(" ({:.1}s)", ms as f64 / 1000.0))
+                .unwrap_or_default();
+            let colour = if *success { "\x1b[32m" } else { "\x1b[31m" };
+            let display = format!("{}{}{}\x1b[0m", colour, status, duration_str);
+
+            let tui_event = duration_ms.map(|ms| TuiEvent::IterationComplete {
+                duration_secs: ms as f64 / 1000.0,
+            });
+
+            (Some(display), tui_event)
+        }
+        StreamEvent::Error { message } => {
+            let display = format!("\x1b[31m✗ Error: {}\x1b[0m", message);
+            let tui_event = TuiEvent::Error(message.clone());
+            (Some(display), Some(tui_event))
+        }
+        StreamEvent::Unknown { .. } => (None, None),
+    }
+}

--- a/src/runner/output_sink.rs
+++ b/src/runner/output_sink.rs
@@ -107,9 +107,9 @@ impl OutputSink for TuiSink {
                 || text.contains("AFK_COMPLETE")
                 || text.contains("AFK_STOP")
             {
-                let _ = self
-                    .tx
-                    .send(TuiEvent::OutputLine("✓ Completion signal detected".to_string()));
+                let _ = self.tx.send(TuiEvent::OutputLine(
+                    "✓ Completion signal detected".to_string(),
+                ));
                 // Caller handles the kill — we just report
             }
         }
@@ -204,15 +204,13 @@ impl OutputSink for TuiSink {
     }
 
     fn on_completion(&mut self) {
-        let _ = self
-            .tx
-            .send(TuiEvent::OutputLine("✓ Completion signal detected".to_string()));
+        let _ = self.tx.send(TuiEvent::OutputLine(
+            "✓ Completion signal detected".to_string(),
+        ));
     }
 
     fn on_warning(&mut self, msg: &str) {
-        let _ = self
-            .tx
-            .send(TuiEvent::Warning(format!("Warning: {msg}")));
+        let _ = self.tx.send(TuiEvent::Warning(format!("Warning: {msg}")));
     }
 
     fn contains_completion_signal(&self, text: &str) -> bool {
@@ -284,8 +282,8 @@ pub fn stream_subprocess_output(
                         // Parser returned None — decide whether to display or suppress.
                         // JSON-shaped lines are suppressed (they're NDJSON metadata);
                         // plain text is displayed (fallback for CLIs without stream-json).
-                        let is_json = line.trim_start().starts_with('{')
-                            && line.trim_end().ends_with('}');
+                        let is_json =
+                            line.trim_start().starts_with('{') && line.trim_end().ends_with('}');
 
                         if is_json {
                             // Silently skip, but still check for embedded completion signals

--- a/src/runner/pty_spawn.rs
+++ b/src/runner/pty_spawn.rs
@@ -10,6 +10,7 @@
 
 use portable_pty::{native_pty_system, Child as PtyChild, CommandBuilder, MasterPty, PtySize};
 use std::io::{self, BufRead, BufReader, Read};
+use vte::{Parser, Perform};
 
 /// A subprocess spawned under a PTY, providing an ANSI-stripped reader
 /// and process lifecycle methods compatible with `stream_subprocess_output`.
@@ -87,15 +88,49 @@ impl PtyProcess {
 // ANSI escape stripping adapter
 // ---------------------------------------------------------------------------
 
+/// Collects printable output while discarding ANSI control sequences.
+#[derive(Default)]
+struct StripAnsiPerformer {
+    out: Vec<u8>,
+}
+
+impl Perform for StripAnsiPerformer {
+    fn print(&mut self, c: char) {
+        let mut buf = [0u8; 4];
+        self.out
+            .extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+    }
+
+    fn execute(&mut self, byte: u8) {
+        // Preserve line-oriented control bytes used by the streaming loop.
+        if matches!(byte, b'\n' | b'\r' | b'\t') {
+            self.out.push(byte);
+        }
+    }
+
+    fn hook(&mut self, _: &vte::Params, _: &[u8], _: bool, _: char) {}
+
+    fn put(&mut self, _: u8) {}
+
+    fn unhook(&mut self) {}
+
+    fn osc_dispatch(&mut self, _: &[&[u8]], _: bool) {}
+
+    fn csi_dispatch(&mut self, _: &vte::Params, _: &[u8], _: bool, _: char) {}
+
+    fn esc_dispatch(&mut self, _: &[u8], _: bool, _: u8) {}
+}
+
 /// A `Read` adapter that strips ANSI escape sequences from the underlying reader.
 ///
-/// Reads raw bytes in chunks, passes them through `strip_ansi_escapes::strip()`,
-/// and serves the cleaned output. This sits between the PTY master and the
-/// `BufReader` that feeds `reader.lines()`.
+/// Uses a stateful `vte::Parser`, which correctly handles escape sequences
+/// that span multiple read chunks.
 struct AnsiStrippingReader {
     inner: Box<dyn Read + Send>,
     buffer: Vec<u8>,
     pos: usize,
+    parser: Parser,
+    performer: StripAnsiPerformer,
 }
 
 impl AnsiStrippingReader {
@@ -104,6 +139,8 @@ impl AnsiStrippingReader {
             inner,
             buffer: Vec::new(),
             pos: 0,
+            parser: Parser::new(),
+            performer: StripAnsiPerformer::default(),
         }
     }
 }
@@ -118,16 +155,26 @@ impl Read for AnsiStrippingReader {
             return Ok(n);
         }
 
-        // Read a chunk of raw PTY output.
-        let mut raw = [0u8; 4096];
-        let n = self.inner.read(&mut raw)?;
-        if n == 0 {
-            return Ok(0); // EOF
-        }
+        loop {
+            // Read a chunk of raw PTY output.
+            let mut raw = [0u8; 4096];
+            let n = self.inner.read(&mut raw)?;
+            if n == 0 {
+                return Ok(0); // EOF
+            }
 
-        // Strip ANSI escape sequences and buffer the result.
-        self.buffer = strip_ansi_escapes::strip(&raw[..n]);
-        self.pos = 0;
+            // Parse bytes incrementally with stateful ANSI parser.
+            self.parser.advance(&mut self.performer, &raw[..n]);
+
+            // Grab newly rendered printable output.
+            if !self.performer.out.is_empty() {
+                self.buffer = std::mem::take(&mut self.performer.out);
+                self.pos = 0;
+                break;
+            }
+
+            // Chunk may contain only control/escape bytes; keep reading.
+        }
 
         let out_n = std::cmp::min(buf.len(), self.buffer.len());
         buf[..out_n].copy_from_slice(&self.buffer[..out_n]);
@@ -136,13 +183,41 @@ impl Read for AnsiStrippingReader {
     }
 }
 
-// Send is safe: inner reader is Send, buffer is owned.
-unsafe impl Send for AnsiStrippingReader {}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    struct ChunkedReader {
+        data: Vec<u8>,
+        pos: usize,
+        chunk_size: usize,
+    }
+
+    impl ChunkedReader {
+        fn new(data: Vec<u8>, chunk_size: usize) -> Self {
+            Self {
+                data,
+                pos: 0,
+                chunk_size,
+            }
+        }
+    }
+
+    impl Read for ChunkedReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.pos >= self.data.len() {
+                return Ok(0);
+            }
+            let n = std::cmp::min(
+                std::cmp::min(buf.len(), self.chunk_size),
+                self.data.len() - self.pos,
+            );
+            buf[..n].copy_from_slice(&self.data[self.pos..self.pos + n]);
+            self.pos += n;
+            Ok(n)
+        }
+    }
 
     #[test]
     fn test_ansi_stripping_reader_plain_text() {
@@ -173,5 +248,16 @@ mod tests {
         let mut line = String::new();
         reader.read_line(&mut line).unwrap();
         assert_eq!(line.trim(), "{\"type\":\"assistant\",\"text\":\"hello\"}");
+    }
+
+    #[test]
+    fn test_ansi_stripping_reader_split_escape_sequences() {
+        // Deliberately split CSI escapes across chunk boundaries.
+        let input = b"\x1b[31mred\x1b[0m\n".to_vec();
+        let inner: Box<dyn Read + Send> = Box::new(ChunkedReader::new(input, 2));
+        let mut reader = BufReader::new(AnsiStrippingReader::new(inner));
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        assert_eq!(line, "red\n");
     }
 }

--- a/src/runner/pty_spawn.rs
+++ b/src/runner/pty_spawn.rs
@@ -1,0 +1,177 @@
+//! PTY-based subprocess spawning with ANSI escape stripping.
+//!
+//! When compiled with `--features pty`, this module provides an alternative
+//! to piped stdout: the AI CLI is spawned under a pseudo-terminal so it
+//! believes it's talking to a real terminal. Raw PTY output is stripped of
+//! ANSI escape sequences before being fed to the streaming loop.
+//!
+//! **Known limitation:** A PTY merges stdout and stderr into a single stream,
+//! so separate stderr capture is not available in this mode.
+
+use portable_pty::{native_pty_system, Child as PtyChild, CommandBuilder, MasterPty, PtySize};
+use std::io::{self, BufRead, BufReader, Read};
+
+/// A subprocess spawned under a PTY, providing an ANSI-stripped reader
+/// and process lifecycle methods compatible with `stream_subprocess_output`.
+pub struct PtyProcess {
+    /// Buffered, ANSI-stripped reader from the PTY master.
+    /// Wrapped in Option so it can be taken separately from the kill handle
+    /// (needed to satisfy the borrow checker when passing to `stream_subprocess_output`).
+    reader: Option<Box<dyn BufRead + Send>>,
+    /// Handle to the child process for kill/wait.
+    child: Box<dyn PtyChild + Send>,
+    /// Keep the master PTY alive for the lifetime of the process.
+    _master: Box<dyn MasterPty + Send>,
+}
+
+impl PtyProcess {
+    /// Spawn a command under a PTY.
+    ///
+    /// `cmd_parts` is the command + arguments (e.g. `["claude", "--dangerously-skip-permissions"]`).
+    /// `prompt` is appended as the final argument.
+    ///
+    /// Returns a `PtyProcess` whose `reader` yields ANSI-stripped, line-buffered output.
+    pub fn spawn(cmd_parts: &[String], prompt: &str) -> anyhow::Result<Self> {
+        let pty_system = native_pty_system();
+        let pair = pty_system.openpty(PtySize {
+            rows: 50,
+            cols: 220,
+            pixel_width: 0,
+            pixel_height: 0,
+        })?;
+
+        let mut cmd = CommandBuilder::new(&cmd_parts[0]);
+        for arg in &cmd_parts[1..] {
+            cmd.arg(arg);
+        }
+        cmd.arg(prompt);
+
+        let child = pair.slave.spawn_command(cmd)?;
+        // Close the slave end in the parent — the child owns it now.
+        drop(pair.slave);
+
+        let raw_reader = pair.master.try_clone_reader()?;
+        let stripped = AnsiStrippingReader::new(raw_reader);
+        let reader: Box<dyn BufRead + Send> = Box::new(BufReader::new(stripped));
+
+        Ok(Self {
+            reader: Some(reader),
+            child,
+            _master: pair.master,
+        })
+    }
+
+    /// Take the reader out of this process handle.
+    ///
+    /// Call this before creating a kill closure so the borrow checker
+    /// allows both the reader and kill closure to coexist.
+    pub fn take_reader(&mut self) -> Box<dyn BufRead + Send> {
+        self.reader.take().expect("reader already taken")
+    }
+
+    /// Kill the child process.
+    pub fn kill(&mut self) {
+        let _ = self.child.kill();
+    }
+
+    /// Wait for the child process to exit, returning success/failure.
+    pub fn wait(&mut self) -> bool {
+        self.child
+            .wait()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ANSI escape stripping adapter
+// ---------------------------------------------------------------------------
+
+/// A `Read` adapter that strips ANSI escape sequences from the underlying reader.
+///
+/// Reads raw bytes in chunks, passes them through `strip_ansi_escapes::strip()`,
+/// and serves the cleaned output. This sits between the PTY master and the
+/// `BufReader` that feeds `reader.lines()`.
+struct AnsiStrippingReader {
+    inner: Box<dyn Read + Send>,
+    buffer: Vec<u8>,
+    pos: usize,
+}
+
+impl AnsiStrippingReader {
+    fn new(inner: Box<dyn Read + Send>) -> Self {
+        Self {
+            inner,
+            buffer: Vec::new(),
+            pos: 0,
+        }
+    }
+}
+
+impl Read for AnsiStrippingReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // Serve from buffered stripped data first.
+        if self.pos < self.buffer.len() {
+            let n = std::cmp::min(buf.len(), self.buffer.len() - self.pos);
+            buf[..n].copy_from_slice(&self.buffer[self.pos..self.pos + n]);
+            self.pos += n;
+            return Ok(n);
+        }
+
+        // Read a chunk of raw PTY output.
+        let mut raw = [0u8; 4096];
+        let n = self.inner.read(&mut raw)?;
+        if n == 0 {
+            return Ok(0); // EOF
+        }
+
+        // Strip ANSI escape sequences and buffer the result.
+        self.buffer = strip_ansi_escapes::strip(&raw[..n]);
+        self.pos = 0;
+
+        let out_n = std::cmp::min(buf.len(), self.buffer.len());
+        buf[..out_n].copy_from_slice(&self.buffer[..out_n]);
+        self.pos = out_n;
+        Ok(out_n)
+    }
+}
+
+// Send is safe: inner reader is Send, buffer is owned.
+unsafe impl Send for AnsiStrippingReader {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_ansi_stripping_reader_plain_text() {
+        let input = b"hello world\n";
+        let inner: Box<dyn Read + Send> = Box::new(Cursor::new(input.to_vec()));
+        let mut reader = AnsiStrippingReader::new(inner);
+        let mut buf = vec![0u8; 64];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"hello world\n");
+    }
+
+    #[test]
+    fn test_ansi_stripping_reader_removes_escapes() {
+        // "\x1b[31mred\x1b[0m" → "red"
+        let input = b"\x1b[31mred\x1b[0m\n";
+        let inner: Box<dyn Read + Send> = Box::new(Cursor::new(input.to_vec()));
+        let mut reader = AnsiStrippingReader::new(inner);
+        let mut buf = vec![0u8; 64];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"red\n");
+    }
+
+    #[test]
+    fn test_ansi_stripping_reader_json_preserved() {
+        let input = b"\x1b[0m{\"type\":\"assistant\",\"text\":\"hello\"}\n\x1b[0m";
+        let inner: Box<dyn Read + Send> = Box::new(Cursor::new(input.to_vec()));
+        let mut reader = BufReader::new(AnsiStrippingReader::new(inner));
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        assert_eq!(line.trim(), "{\"type\":\"assistant\",\"text\":\"hello\"}");
+    }
+}

--- a/src/runner/quality_gates.rs
+++ b/src/runner/quality_gates.rs
@@ -5,6 +5,7 @@
 
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
+use std::thread;
 
 use crate::config::FeedbackLoopsConfig;
 
@@ -98,11 +99,28 @@ pub fn run_quality_gates(feedback_loops: &FeedbackLoopsConfig, verbose: bool) ->
     }
 
     println!();
-    println!("\x1b[1mRunning quality gates...\x1b[0m");
+    println!("\x1b[1mRunning {} quality gates in parallel...\x1b[0m", gates.len());
     println!();
 
-    for (name, cmd) in gates {
-        let gate_result = run_single_gate(&name, &cmd, verbose);
+    // Spawn all gates concurrently
+    let handles: Vec<_> = gates
+        .into_iter()
+        .map(|(name, cmd)| {
+            thread::spawn(move || run_single_gate(&name, &cmd))
+        })
+        .collect();
+
+    // Join all threads and collect results
+    for handle in handles {
+        let gate_result = match handle.join() {
+            Ok(r) => r,
+            Err(_) => GateResult {
+                name: "unknown".to_string(),
+                passed: false,
+                output: "Gate thread panicked".to_string(),
+                duration_seconds: 0.0,
+            },
+        };
 
         let status = if gate_result.passed {
             "\x1b[32m✓\x1b[0m"
@@ -112,7 +130,7 @@ pub fn run_quality_gates(feedback_loops: &FeedbackLoopsConfig, verbose: bool) ->
 
         println!(
             "  {} {} ({:.1}s)",
-            status, name, gate_result.duration_seconds
+            status, gate_result.name, gate_result.duration_seconds
         );
 
         if verbose && !gate_result.output.is_empty() {
@@ -139,7 +157,10 @@ pub fn run_quality_gates(feedback_loops: &FeedbackLoopsConfig, verbose: bool) ->
 }
 
 /// Run a single quality gate.
-fn run_single_gate(name: &str, cmd: &str, _verbose: bool) -> GateResult {
+///
+/// Reads stdout and stderr concurrently to prevent pipe-buffer deadlock
+/// when a gate produces more output than the OS pipe buffer can hold.
+fn run_single_gate(name: &str, cmd: &str) -> GateResult {
     let start = std::time::Instant::now();
 
     // Parse command - use shell for complex commands
@@ -164,29 +185,44 @@ fn run_single_gate(name: &str, cmd: &str, _verbose: bool) -> GateResult {
         }
     };
 
-    // Collect output
-    let mut output = String::new();
+    // Read stdout and stderr concurrently to avoid pipe-buffer deadlock.
+    // If we read one to completion before the other, the child can block
+    // writing to the unread pipe when the OS buffer fills (~64KB linux, ~512KB macOS).
+    let stdout_handle = process.stdout.take().map(|stdout| {
+        thread::spawn(move || {
+            let reader = BufReader::new(stdout);
+            let mut out = String::new();
+            for line in reader.lines().map_while(Result::ok) {
+                out.push_str(&line);
+                out.push('\n');
+            }
+            out
+        })
+    });
 
-    if let Some(stdout) = process.stdout.take() {
-        let reader = BufReader::new(stdout);
-        for line in reader.lines().map_while(Result::ok) {
-            output.push_str(&line);
-            output.push('\n');
-        }
-    }
+    let stderr_handle = process.stderr.take().map(|stderr| {
+        thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            let mut out = String::new();
+            for line in reader.lines().map_while(Result::ok) {
+                out.push_str(&line);
+                out.push('\n');
+            }
+            out
+        })
+    });
 
-    if let Some(stderr) = process.stderr.take() {
-        let reader = BufReader::new(stderr);
-        for line in reader.lines().map_while(Result::ok) {
-            output.push_str(&line);
-            output.push('\n');
-        }
-    }
+    let stdout_output = stdout_handle
+        .map(|h| h.join().unwrap_or_default())
+        .unwrap_or_default();
+    let stderr_output = stderr_handle
+        .map(|h| h.join().unwrap_or_default())
+        .unwrap_or_default();
 
-    // Wait for process with timeout
-    let result = process.wait();
+    let output = format!("{stdout_output}{stderr_output}");
 
-    let passed = match result {
+    // Wait for process to finish
+    let passed = match process.wait() {
         Ok(status) => status.success(),
         Err(_) => false,
     };
@@ -353,25 +389,58 @@ mod tests {
 
     #[test]
     fn test_run_single_gate_success() {
-        // This test runs an actual command - 'true' always succeeds
-        let result = run_single_gate("test", "true", false);
+        let result = run_single_gate("test", "true");
         assert!(result.passed);
         assert_eq!(result.name, "test");
     }
 
     #[test]
     fn test_run_single_gate_failure() {
-        // This test runs an actual command - 'false' always fails
-        let result = run_single_gate("test", "false", false);
+        let result = run_single_gate("test", "false");
         assert!(!result.passed);
         assert_eq!(result.name, "test");
     }
 
     #[test]
     fn test_run_single_gate_with_output() {
-        let result = run_single_gate("echo", "echo hello", false);
+        let result = run_single_gate("echo", "echo hello");
         assert!(result.passed);
         assert!(result.output.contains("hello"));
+    }
+
+    #[test]
+    fn test_run_single_gate_large_stderr_no_deadlock() {
+        // Produces >64KB of stderr output. Without concurrent stream reading,
+        // this would deadlock because the parent blocks reading stdout while
+        // the child blocks writing to the full stderr pipe buffer.
+        let result = run_single_gate(
+            "large-stderr",
+            "for i in $(seq 1 5000); do echo \"stderr line $i\" >&2; done; echo done",
+        );
+        assert!(result.passed);
+        assert!(result.output.contains("done"));
+        assert!(result.output.contains("stderr line 5000"));
+    }
+
+    #[test]
+    fn test_run_quality_gates_parallel_timing() {
+        // Three gates each sleeping 0.3s. Sequential would take ~0.9s,
+        // parallel should complete in ~0.3s (plus overhead).
+        let config = FeedbackLoopsConfig {
+            lint: Some("sleep 0.3".to_string()),
+            test: Some("sleep 0.3".to_string()),
+            build: Some("sleep 0.3".to_string()),
+            ..Default::default()
+        };
+
+        let start = std::time::Instant::now();
+        let result = run_quality_gates(&config, false);
+        let elapsed = start.elapsed().as_secs_f64();
+
+        assert!(result.all_passed);
+        assert_eq!(result.gates.len(), 3);
+        // Should be well under the sequential time of 0.9s
+        assert!(elapsed < 0.8, "Parallel gates took {:.2}s, expected < 0.8s", elapsed);
     }
 
     #[test]

--- a/src/runner/quality_gates.rs
+++ b/src/runner/quality_gates.rs
@@ -410,6 +410,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn test_run_single_gate_large_stderr_no_deadlock() {
         // Produces >64KB of stderr output. Without concurrent stream reading,
         // this would deadlock because the parent blocks reading stdout while
@@ -424,6 +425,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn test_run_quality_gates_parallel_timing() {
         // Three gates each sleeping 0.3s. Sequential would take ~0.9s,
         // parallel should complete in ~0.3s (plus overhead).

--- a/src/runner/quality_gates.rs
+++ b/src/runner/quality_gates.rs
@@ -99,15 +99,16 @@ pub fn run_quality_gates(feedback_loops: &FeedbackLoopsConfig, verbose: bool) ->
     }
 
     println!();
-    println!("\x1b[1mRunning {} quality gates in parallel...\x1b[0m", gates.len());
+    println!(
+        "\x1b[1mRunning {} quality gates in parallel...\x1b[0m",
+        gates.len()
+    );
     println!();
 
     // Spawn all gates concurrently
     let handles: Vec<_> = gates
         .into_iter()
-        .map(|(name, cmd)| {
-            thread::spawn(move || run_single_gate(&name, &cmd))
-        })
+        .map(|(name, cmd)| thread::spawn(move || run_single_gate(&name, &cmd)))
         .collect();
 
     // Join all threads and collect results
@@ -440,7 +441,11 @@ mod tests {
         assert!(result.all_passed);
         assert_eq!(result.gates.len(), 3);
         // Should be well under the sequential time of 0.9s
-        assert!(elapsed < 0.8, "Parallel gates took {:.2}s, expected < 0.8s", elapsed);
+        assert!(
+            elapsed < 0.8,
+            "Parallel gates took {:.2}s, expected < 0.8s",
+            elapsed
+        );
     }
 
     #[test]

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -16,6 +16,8 @@ pub use json::load_json_tasks;
 pub use markdown::load_markdown_tasks;
 pub use openspec::load_openspec_tasks;
 
+use std::thread;
+
 use crate::config::{SourceConfig, SourceType};
 use crate::prd::UserStory;
 
@@ -47,7 +49,28 @@ use crate::prd::UserStory;
 /// ```
 #[must_use]
 pub fn aggregate_tasks(sources: &[SourceConfig]) -> Vec<UserStory> {
-    sources.iter().flat_map(load_from_source).collect()
+    if sources.len() <= 1 {
+        // Fast path: no thread overhead for single source
+        return sources.iter().flat_map(load_from_source).collect();
+    }
+
+    // Spawn one thread per source and join in order to preserve source-declaration ordering
+    let handles: Vec<_> = sources
+        .iter()
+        .cloned()
+        .map(|source| thread::spawn(move || load_from_source(&source)))
+        .collect();
+
+    handles
+        .into_iter()
+        .flat_map(|h| match h.join() {
+            Ok(tasks) => tasks,
+            Err(e) => {
+                eprintln!("Warning: source loader thread panicked: {e:?}");
+                vec![]
+            }
+        })
+        .collect()
 }
 
 /// Load tasks from a single source.

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -57,8 +57,10 @@ pub fn aggregate_tasks(sources: &[SourceConfig]) -> Vec<UserStory> {
     // Spawn one thread per source and join in order to preserve source-declaration ordering
     let handles: Vec<_> = sources
         .iter()
-        .cloned()
-        .map(|source| thread::spawn(move || load_from_source(&source)))
+        .map(|source| {
+            let source = source.clone();
+            thread::spawn(move || load_from_source(&source))
+        })
         .collect();
 
     handles


### PR DESCRIPTION
Implements the performance review recommendations end-to-end for this branch, plus follow-up polish to satisfy CI.

See `docs/performance-review.md` for the full analysis and rationale.

## What Landed

### Runner and Streaming
- Added unified streaming abstraction in `src/runner/output_sink.rs` (`OutputSink`, `ConsoleSink`, `TuiSink`) and routed both console/TUI paths through `stream_subprocess_output`.
- Fixed TUI NDJSON leakage so raw JSON lines are suppressed consistently with non-TUI behavior.
- Added optional PTY execution path behind `pty` feature in `src/runner/pty_spawn.rs` and wired both spawn sites to support PTY mode.
- Added PTY validation spike example in `examples/pty_spike.rs`.

### Loop/Prompt Performance
- Replaced per-line `Vec<String> + concat()` buffering with a single preallocated `String` in hot streaming paths.
- Added PRD mtime cache in `src/runner/controller.rs` to avoid redundant `tasks.json` reloads/parsing in the loop.
- Added template cache in `src/prompt/mod.rs` (`Mutex<Option<(String, Tera)>>`) to avoid recompiling unchanged templates.
- Fixed phantom iteration increments/writes when all stories are already complete.
- Pre-sized feedback loop `HashMap` in prompt generation.

### Concurrency Improvements
- Parallelized quality gates in `src/runner/quality_gates.rs`.
- Fixed quality gate pipe deadlock risk by reading stdout/stderr concurrently.
- Parallelized multi-source aggregation in `src/sources/mod.rs` with single-source fast path and panic-safe joins.

### Update Path
- Migrated self-update HTTP path from `reqwest::blocking` to async `reqwest::Client` in `src/cli/update.rs`.
- Removed reqwest `blocking` feature from `Cargo.toml`.

### Documentation
- Updated `README.md` and docs (`docs/architecture.md`, `docs/user-guide.md`, `docs/performance-review.md`) to reflect the implemented architecture and behavior.
- Added explicit implementation status in `docs/performance-review.md` for phases 1-7 and noted deferred worktree parallel runner as future work.

### CI/Quality Follow-ups
- Applied rustfmt-required formatting adjustments across changed Rust files.
- Fixed clippy failure (`redundant_iter_cloned`) in `src/sources/mod.rs`.

## Scope Notes
- Worktree-based true parallel task execution remains intentionally deferred (documented as future work).
- PTY support is optional and feature-gated at build time (`--features pty`).

## Validation
- CI format/clippy/test workflow run against this branch/PR.
- Added/updated targeted tests in touched modules (quality gates, prompt behavior, streaming behavior, PTY helper tests).